### PR TITLE
no dots in html dom ids else jquery lookup fails

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -149,7 +149,7 @@ class StaffGradedAssignmentXBlock(XBlock):
         template = get_template("staff_graded_assignment/show.html")
         context = {
             "student_state": json.dumps(self.student_state()),
-            "id": self.location.name
+            "id": self.location.name.replace('.','_')
         }
         if self.show_staff_grading_interface():
             context['is_course_staff'] = True


### PR DESCRIPTION
The staff grading-submission modal window will fail to appear if the course name or location name has a period in it.  This is because jquery interprets such id's as a js element lookup (see http://stackoverflow.com/questions/17403636/jquery-x-does-not-work-but-document-getelementbyidx-works).

This PR fixes the issue by replacing "." with "_" in the Context id string.
