### PR TITLE
Fix for templates missing on install of XBlock.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,15 +4,15 @@ import os
 from setuptools import setup, find_packages
 
 
-def package_data(pkg, root):
+def package_data(pkg, root_list):
     """Generic function to find package_data for `pkg` under `root`."""
     data = []
-    for dirname, _, files in os.walk(os.path.join(pkg, root)):
-        for fname in files:
-            data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
+    for root in root_list:
+        for dirname, _, files in os.walk(os.path.join(pkg, root)):
+            for fname in files:
+                data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
 
     return {pkg: data}
-
 
 setup(
     name='edx-sga',
@@ -28,5 +28,5 @@ setup(
             'edx_sga = edx_sga:StaffGradedAssignmentXBlock',
         ]
     },
-    package_data=package_data("edx_sga", "static"),
+    package_data=package_data("edx_sga", ["static", "templates"]),
 )


### PR DESCRIPTION
Fix for templates missing after install.

Modified:
setup.py to include templates dir in package_data
sga.py from get_template to render_template
tests.py to fix resulting broken tests
