### PR TITLE
Change maximum score to integer

### DIFF
--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -148,6 +148,9 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                 if (isNaN(score)) {
                     form.find(".error").html("<br/>Grade must be a number.");
                 } 
+                else if (score != parseInt(score)) {
+                    form.find(".error").html("<br/>Grade must be an integer.");
+                }
                 else if (score < 0) {
                     form.find(".error").html("<br/>Grade must be positive.");
                 }


### PR DESCRIPTION
To match the submissions API, the max score field is now an integer
Shows error message in LMS if user enters float
Studio now checks that numbers are positive integers before saving

@pdpinch and @dcadams