### PR TITLE
added display name on sga

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -224,6 +224,7 @@ class StaffGradedAssignmentXBlock(XBlock):
             graded = None
 
         return {
+            "display_name": self.display_name,
             "uploaded": uploaded,
             "annotated": annotated,
             "graded": graded,
@@ -280,6 +281,7 @@ class StaffGradedAssignmentXBlock(XBlock):
         return {
             'assignments': list(get_student_data()),
             'max_score': self.max_score(),
+            'display_name': self.display_name
         }
 
     def studio_view(self, context=None):

--- a/edx_sga/static/css/edx_sga.css
+++ b/edx_sga/static/css/edx_sga.css
@@ -123,3 +123,6 @@
    color: #FFF;
 }
 
+.sga-block .display_name {
+    color: inherit;
+}

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -91,6 +91,10 @@ function StaffGradedAssignmentXBlock(runtime, element) {
         function renderStaffGrading(data) {
             $(".grade-modal").hide();
 
+            if (data.display_name != ""){
+                $(".sga-block .display_name").html(data.display_name);
+            }
+
             // Add download urls to template context
             data.downloadUrl = staffDownloadUrl;
             data.annotatedUrl = staffAnnotatedUrl;

--- a/edx_sga/templates/staff_graded_assignment/show.html
+++ b/edx_sga/templates/staff_graded_assignment/show.html
@@ -3,6 +3,9 @@
 <div class="sga-block" data-state="{{ student_state }}" 
      data-staff="{{ is_course_staff }}">
   <script type="text/template" id="sga-tmpl">
+    <% if (display_name) { %>
+       <b><%= display_name %></b>
+    <% } %>
     <% if (uploaded) { %>
       <p><b>File uploaded</b> 
         <a href="<%= downloadUrl %>"><%= uploaded.filename %></a></p>
@@ -116,7 +119,7 @@
 
   <section aria-hidden="true" class="modal staff-modal" id="{{ id }}-grade" style="height: 75%">
     <div class="inner-wrapper" style="color: black; overflow: auto;">
-      <header><h2>{% trans "Staff Graded Assignment" %}</h2></header>
+      <header><h2><span class="display_name">{{ display_name }}</span> - {% trans "Staff Graded Assignment" %}</h2></header>
       <br/>
       <div id="grade-info" style="display: block;">
         Loading...

--- a/edx_sga/tests.py
+++ b/edx_sga/tests.py
@@ -56,7 +56,7 @@ class StaffGradedAssignmentXblockTests(unittest.TestCase):
         patcher.start()
         self.addCleanup(patcher.stop)
 
-    def make_one(self, **kw):
+    def make_one(self, display_name=None, **kw):
         from edx_sga.sga import StaffGradedAssignmentXBlock as cls
         field_data = DictFieldData(kw)
         block = cls(self.runtime, field_data, self.scope_ids)
@@ -67,6 +67,10 @@ class StaffGradedAssignmentXblockTests(unittest.TestCase):
         block.course_id = self.course_id
         block.scope_ids.usage_id = 'XXX'
         block.category = 'problem'
+
+        if display_name:
+            block.display_name = display_name
+
         block.start = datetime.datetime(2010, 5, 12, 2, 42, tzinfo=pytz.utc)
         return block
 
@@ -140,7 +144,7 @@ class StaffGradedAssignmentXblockTests(unittest.TestCase):
     @mock.patch('edx_sga.sga.render_template')
     @mock.patch('edx_sga.sga.Fragment')
     def test_student_view(self, Fragment, render_template):
-        block = self.make_one()
+        block = self.make_one("Custom name")
         self.personalize(block, **self.make_student(block, 'fred'))
         fragment = block.student_view()
         render_template.assert_called_once
@@ -153,6 +157,10 @@ class StaffGradedAssignmentXblockTests(unittest.TestCase):
         self.assertEqual(context['is_course_staff'], True)
         self.assertEqual(context['id'], 'name')
         student_state = json.loads(context['student_state'])
+        self.assertEqual(
+            student_state['display_name'],
+            "Custom name"
+        )
         self.assertEqual(student_state['uploaded'], None)
         self.assertEqual(student_state['annotated'], None)
         self.assertEqual(student_state['upload_allowed'], True)
@@ -207,6 +215,10 @@ class StaffGradedAssignmentXblockTests(unittest.TestCase):
         self.assertEqual(context['is_course_staff'], True)
         self.assertEqual(context['id'], 'name')
         student_state = json.loads(context['student_state'])
+        self.assertEqual(
+            student_state['display_name'],
+            "Staff Graded Assignment"
+        )
         self.assertEqual(student_state['uploaded'], {u'filename': u'foo.txt'})
         self.assertEqual(student_state['annotated'], None)
         self.assertEqual(student_state['upload_allowed'], False)


### PR DESCRIPTION
Added XBlock display name on lms plus added test cases. In this issue we need to show user defined xblock display name on lms. By default the value of display name is "Staff Graded Assignment". User can modify it from studio.

#71 