### PR TITLE
Implement support for multiply SGA elements at one vertical

### DIFF
--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -27,7 +27,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
             var content = $(element).find('#sga-content').html(template(state));
 
             // Set up file upload
-            $(content).find('.fileupload').fileupload({
+            var fileUpload = $(content).find('.fileupload').fileupload({
                 url: uploadUrl,
                 add: function(e, data) {
                     var do_upload = $(content).find('.upload').html('');
@@ -100,6 +100,8 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                     }
                 }
             });
+
+            updateChangeEvent(fileUpload);
         }
 
         function renderStaffGrading(data) {
@@ -133,7 +135,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
             $(element).find('#grade-info .fileupload').each(function() {
                 var row = $(this).parents("tr");
                 var url = staffUploadUrl + "?module_id=" + row.data("module_id");
-                $(this).fileupload({
+                var fileUpload = $(this).fileupload({
                     url: url,
                     progressall: function(e, data) {
                         var percent = parseInt(data.loaded / data.total * 100, 10);
@@ -147,6 +149,8 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                             3000);
                     }
                 });
+
+                updateChangeEvent(fileUpload);
             });
         }
 
@@ -201,6 +205,24 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                 setTimeout(function() {
                     $('#grade-submissions-button').click();
                 }, 225);
+            });
+        }
+
+        function updateChangeEvent(fileUploadObj) {
+            fileUploadObj.off('change').on('change', function (e) {
+                var that = $(this).data('blueimpFileupload'),
+                    data = {
+                        fileInput: $(e.target),
+                        form: $(e.target.form)
+                    };
+
+                that._getFileInputFiles(data.fileInput).always(function (files) {
+                    data.files = files;
+                    if (that.options.replaceFileInput) {
+                        that._replaceFileInput(data.fileInput);
+                    }
+                    that._onAdd(e, data);
+                });
             });
         }
 


### PR DESCRIPTION
Hi!

I was able to fix the #81 (Support multiple SGA types in one vertical) issue at our current project with a "hack" presented in the current PR.

The idea to consists in rewriting the `change` event on `fileupload` object (provided by the [jQuery-File-Upload](https://github.com/blueimp/jQuery-File-Upload) plugin, used it `edx-sga` internally) to prevent recursion of call stack.

Current implementation of the `_onChange` handler depends on the version of `jQuery-File-Upload`, the latest for example https://github.com/blueimp/jQuery-File-Upload/blob/master/js/jquery.fileupload.js#L1209-L1228 but all of them shared such behavior:
```javascript
...
if (that._trigger(
        'change',
        $.Event('change', {delegatedEvent: e}),
        data
    ) !== false) {
        that._onAdd(e, data);
}
...
```
or for the older versions
```javascript
...
if (that._trigger('change', e, data) !== false) {
    that._onAdd(e, data);
}
...   
```
And rewritten version just avoid this condition, calling  ``` that._onAdd(e, data);``` without `change` event triggering.

It fixed both problems "Upload file on lms/sga" and "Upload annotated file on Grade submissions dialog on lms/sga" for me.

I am not sure if this solution is good enough to be merged but at least it could be used temporary for everybody faced original issue until the better one would be provided :blush:

