### PR TITLE
Allow not only english language file uploads

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -520,7 +520,8 @@ class StaffGradedAssignmentXBlock(XBlock):
         return Response(
             app_iter=app_iter,
             content_type=mime_type,
-            content_disposition="attachment; filename=" + filename)
+            content_disposition=("attachment; filename=" +
+                                 filename.encode('utf-8')))
 
     @XBlock.handler
     def get_staff_grading_data(self, request, suffix=''):

--- a/edx_sga/tests.py
+++ b/edx_sga/tests.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 """
 Tests for SGA
 """
@@ -436,6 +437,38 @@ class StaffGradedAssignmentXblockTests(unittest.TestCase):
         path = pkg_resources.resource_filename(__package__, 'tests.py')
         expected = open(path, 'rb').read()
         upload = mock.Mock(file=DummyUpload(path, 'test.txt'))
+        block = self.make_one()
+        student = self.make_student(block, 'fred')
+        self.personalize(block, **student)
+        block.upload_assignment(mock.Mock(params={'assignment': upload}))
+        response = block.staff_download(mock.Mock(params={
+            'student_id': student['item'].student_id}))
+        self.assertEqual(response.body, expected)
+
+    def test_download_annotated_unicode_filename(self):
+        """
+        Tests download annotated assignment
+        with filename in unicode for non staff member.
+        """
+        path = pkg_resources.resource_filename(__package__, 'tests.py')
+        expected = open(path, 'rb').read()
+        upload = mock.Mock(file=DummyUpload(path, 'файл.txt'))
+        block = self.make_one()
+        fred = self.make_student(block, "fred2")
+        block.staff_upload_annotated(mock.Mock(params={
+            'annotated': upload,
+            'module_id': fred['module'].id}))
+        self.personalize(block, **fred)
+        response = block.download_annotated(None)
+        self.assertEqual(response.body, expected)
+
+    def test_staff_download_unicode_filename(self):
+        """
+        Tests download assignment with filename in unicode for staff.
+        """
+        path = pkg_resources.resource_filename(__package__, 'tests.py')
+        expected = open(path, 'rb').read()
+        upload = mock.Mock(file=DummyUpload(path, 'файл.txt'))
         block = self.make_one()
         student = self.make_student(block, 'fred')
         self.personalize(block, **student)


### PR DESCRIPTION
Hi!

Currently a student as well as staff member could
upload any file as part of submission or grade.

Unfortunately when the user trying to DOWNLOAD
the files that filename is not in English (Russian for example)
we got an 500 error on the server.

This occurs because of Python encoding rules, and original
issue is something like this:

"UnicodeEncodeError: 'latin-1' codec can't encode characters
in position 21-24: ordinal not in range(256)"

(Depends on the filename)

This patch is fixing it.