### PR TITLE
Fix for comma in uploaded filename

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -528,7 +528,7 @@ class StaffGradedAssignmentXBlock(XBlock):
             return Response(
                 app_iter=app_iter,
                 content_type=mime_type,
-                content_disposition="attachment; filename=" + filename.encode('utf-8'))
+                content_disposition="attachment; filename=\"" + filename.encode('utf-8') + "\"")
         except IOError:
             if require_staff:
                 return Response(


### PR DESCRIPTION
Uploading a file with a comma in the filename causes subsequent download of the file to fail on Chrome only. The fix is to quote the attachment filename.

More information here: http://stackoverflow.com/questions/13578428/duplicate-headers-received-from-server
