### PR TITLE
Removed import in __init__

### DIFF
--- a/edx_sga/__init__.py
+++ b/edx_sga/__init__.py
@@ -1,5 +1,3 @@
 """
 Module for StaffGradedAssignmentXBlock.
 """
-
-from .sga import StaffGradedAssignmentXBlock

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='edx-sga',
-    version='0.5.0',
+    version='0.5.1',
     description='edx-sga Staff Graded Assignment XBlock',
     license='Affero GNU General Public License v3 (GPLv3)',
     url="https://github.com/mitodl/edx-sga",
@@ -29,7 +29,7 @@ setup(
     ],
     entry_points={
         'xblock.v1': [
-            'edx_sga = edx_sga:StaffGradedAssignmentXBlock',
+            'edx_sga = edx_sga.sga:StaffGradedAssignmentXBlock',
         ]
     },
     package_data=package_data("edx_sga", ["static", "templates"]),


### PR DESCRIPTION
This import gets called when Django starts. The imported module further imports Django REST Framework code that attempts to call the translation infrastructure before the apps registry is ready. This prevents Django from properly starting and maintainers of edx/edx-platform from upgrading Django REST Framework.