### PR TITLE
Fixed typo in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Try Out on devstack/fullstack
 
      on the second line right after ``{``
 
-   - In ``/edx/app/edxapp/cms.envs.json``, add
+   - In ``/edx/app/edxapp/cms.env.json``, add
 
 	 .. code:: javascript
 


### PR DESCRIPTION
Fixed typo inside the README.rst file. The correct file name is cms.env.json.