### PR TITLE
[WIP] Server side validation for SGA api

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -561,9 +561,20 @@ class StaffGradedAssignmentXBlock(XBlock):
         Persist a score for a student given by staff.
         """
         require(self.is_course_staff())
+        score = request.params.get('grade', None)
+        if not score:
+            log.error(
+                "[enter_grade] Please enter valid grade for course:%s module:%s student:%s",
+                module.course_id,
+                module.module_state_key,
+                module.student.username
+            )
+            return Response(json_body= {
+                "error": "Please enter valid grade"
+            })
         module = StudentModule.objects.get(pk=request.params['module_id'])
         state = json.loads(module.state)
-        score = int(request.params['grade'])
+        score = int(score)
         if self.is_instructor():
             uuid = request.params['submission_id']
             submissions_api.set_score(uuid, score, self.max_score())
@@ -588,6 +599,18 @@ class StaffGradedAssignmentXBlock(XBlock):
         Reset a students score request by staff.
         """
         require(self.is_course_staff())
+        score = request.params.get('grade', None)
+        if not score:
+            log.error(
+                "[remove_grade] Please enter valid grade for course:%s module:%s student:%s",
+                module.course_id,
+                module.module_state_key,
+                module.student.username
+            )
+            return Response(json_body= {
+                "error": "To remove grade, you must have a valid grade submitted first"
+            })
+
         student_id = request.params['student_id']
         submissions_api.reset_score(student_id, unicode(self.course_id), self.block_id)
         module = StudentModule.objects.get(pk=request.params['module_id'])

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -105,7 +105,11 @@ function StaffGradedAssignmentXBlock(runtime, element) {
         }
 
         function renderStaffGrading(data) {
-            $('.grade-modal').hide();
+            if 'error' in data.keys():
+               var form = $(element).find("#enter-grade-form");
+               form.find('.error').html(data['error']);
+            else:
+                $('.grade-modal').hide();
 
             if (data.display_name !== '') {
                 $('.sga-block .display_name').html(data.display_name);


### PR DESCRIPTION
@pdpinch https://openedx.atlassian.net/browse/TNL-6457

- Open sga submissions as staff and try to save empty score
  - What i did is i submit a file ten entered grade 50 and submit.
  - Then i reopened submission and removed my score and pressed `submit`.
  - Got exception.
```python
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 954, in handle_xblock_callback
    return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1060, in _invoke_xblock_handler
    resp = instance.handle(handler, req, suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 89, in handle
    return self.runtime.handle(self, handler_name, request, suffix)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1334, in handle
    return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1025, in handle
    results = handler(request, suffix)
  File "/edx/app/edxapp/venvs/edxapp/src/edx-sga/edx_sga/sga.py", line 429, in enter_grade
    score = int(request.params['grade']
```
<img width="1078" alt="screen shot 2017-02-03 at 10 04 36 pm" src="https://cloud.githubusercontent.com/assets/10431250/22600540/d047dc18-ea5c-11e6-9c37-311008be3dd0.png">

-  After submitting grade (lets say 50) for first time. I ReOpen submissions again and made grade field empty and press `Remove Grade` btn. Saw exception
```python
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 954, in handle_xblock_callback
    return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1060, in _invoke_xblock_handler
    resp = instance.handle(handler, req, suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 89, in handle
    return self.runtime.handle(self, handler_name, request, suffix)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1334, in handle
    return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1025, in handle
    results = handler(request, suffix)
  File "/edx/app/edxapp/venvs/edxapp/src/edx-sga/edx_sga/sga.py", line 446, in remove_grade
    module = StudentModule.objects.get(pk=request.params['module_id'])
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 127, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 325, in get
    clone = self.filter(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 679, in filter
    return self._filter_or_exclude(False, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 697, in _filter_or_exclude
    clone.query.add_q(Q(*args, **kwargs))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1310, in add_q
    clause, require_inner = self._add_q(where_part, self.used_aliases)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1338, in _add_q
    allow_joins=allow_joins, split_subq=split_subq,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1209, in build_filter
    condition = self.build_lookup(lookups, col, value)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/query.py", line 1102, in build_lookup
    return final_lookup(lhs, rhs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/lookups.py", line 105, in __init__
    self.rhs = self.get_prep_lookup()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/lookups.py", line 143, in get_prep_lookup
    return self.lhs.output_field.get_prep_lookup(self.lookup_name, self.rhs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 727, in get_prep_lookup
    return self.get_prep_value(value)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/fields/__init__.py", line 985, in get_prep_value
    return int(value)
ValueError: invalid literal for int() with base 10: 'undefined'
```
<img width="966" alt="screen shot 2017-02-03 at 10 08 25 pm" src="https://cloud.githubusercontent.com/assets/10431250/22600688/713b51e0-ea5d-11e6-8960-0bbb51259bd6.png">

- After submitting grade (lets say 50) for first time. Reopen submission and press `Remove Grade` btn. You will see exception
```python
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/utils/decorators.py", line 145, in inner
    return func(*args, **kwargs)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 954, in handle_xblock_callback
    return _invoke_xblock_handler(request, course_id, usage_id, handler, suffix, course=course)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/module_render.py", line 1060, in _invoke_xblock_handler
    resp = instance.handle(handler, req, suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/mixins.py", line 89, in handle
    return self.runtime.handle(self, handler_name, request, suffix)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1334, in handle
    return super(MetricsMixin, self).handle(block, handler_name, request, suffix=suffix)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 1025, in handle
    results = handler(request, suffix)
  File "/edx/app/edxapp/venvs/edxapp/src/edx-sga/edx_sga/sga.py", line 445, in remove_grade
    submissions_api.reset_score(student_id, self.course_id, self.block_id)
  File "/edx/app/edxapp/venvs/edxapp/src/edx-submissions/submissions/api.py", line 746, in reset_score
    item_id=item_id,
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/models.py", line 453, in submissions_score_reset_handler
    usage_id=usage_id
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/dispatch/dispatcher.py", line 189, in send
    response = receiver(signal=self, sender=sender, **named)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/gating/signals.py", line 24, in handle_score_changed
    course = modulestore().get_course(CourseKey.from_string(kwargs.get('course_id')))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/opaque_keys/__init__.py", line 185, in from_string
    namespace, rest = cls._separate_namespace(serialized)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/opaque_keys/__init__.py", line 205, in _separate_namespace
    namespace, __, rest = serialized.partition(cls.NAMESPACE_SEPARATOR)
AttributeError: 'CourseLocator' object has no attribute 'partition'
```
<img width="1113" alt="screen shot 2017-02-03 at 10 10 48 pm" src="https://cloud.githubusercontent.com/assets/10431250/22600753/c3af47f6-ea5d-11e6-90ea-8c10b508961d.png">
