### PR TITLE
Increase the height of the "Select a File" element

### DIFF
--- a/edx_sga/static/css/edx_sga.css
+++ b/edx_sga/static/css/edx_sga.css
@@ -62,6 +62,7 @@
 	opacity: 0;
 	z-index: 2;
     width: 200px;
+    height: 40px;
     cursor: pointer;
 }
 


### PR DESCRIPTION
By default the height of the "Select a File" element is too short — only the top half of the element is clickable.

If we add `height: 40px` to that element, that problem is fixed.

See the attached images for the before-and-after: http://imgur.com/gallery/AjWi5

Thanks!