### PR TITLE
Serialize block/course locators before sending to submissions API.

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -135,12 +135,36 @@ class StaffGradedAssignmentXBlock(XBlock):
         """
         return self.points
 
+    def _serialize_opaque_key(self, key):
+        """
+        Gracefully handle opaque keys, both before and after the transition.
+        https://github.com/edx/edx-platform/wiki/Opaque-Keys-(Locators)
+
+        Args:
+            key (unicode or OpaqueKey subclass): The key to serialize.
+
+        Returns:
+            unicode
+
+        """
+        if hasattr(key, 'to_deprecated_string'):
+            return key.to_deprecated_string()
+        else:
+            return unicode(key)
+
     @reify
     def block_id(self):
         """
         Return the usage_id of the block.
         """
-        return self.scope_ids.usage_id
+        return self._serialize_opaque_key(self.scope_ids.usage_id)
+
+    @reify
+    def block_course_id(self):
+        """
+        Return the course_id of the block.
+        """
+        return self._serialize_opaque_key(self.course_id)
 
     def student_submission_id(self, submission_id=None):
         # pylint: disable=no-member
@@ -155,9 +179,9 @@ class StaffGradedAssignmentXBlock(XBlock):
             )
         return {
             "student_id": submission_id,
-            "course_id": self.course_id,
+            "course_id": self.block_course_id,
             "item_id": self.block_id,
-            "item_type": 'sga',  # ???
+            "item_type": 'sga',
         }
 
     def get_submission(self, submission_id=None):

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -135,36 +135,19 @@ class StaffGradedAssignmentXBlock(XBlock):
         """
         return self.points
 
-    def _serialize_opaque_key(self, key):
-        """
-        Gracefully handle opaque keys, both before and after the transition.
-        https://github.com/edx/edx-platform/wiki/Opaque-Keys-(Locators)
-
-        Args:
-            key (unicode or OpaqueKey subclass): The key to serialize.
-
-        Returns:
-            unicode
-
-        """
-        if hasattr(key, 'to_deprecated_string'):
-            return key.to_deprecated_string()
-        else:
-            return unicode(key)
-
     @reify
     def block_id(self):
         """
         Return the usage_id of the block.
         """
-        return self._serialize_opaque_key(self.scope_ids.usage_id)
+        return unicode(self.scope_ids.usage_id)
 
     @reify
     def block_course_id(self):
         """
         Return the course_id of the block.
         """
-        return self._serialize_opaque_key(self.course_id)
+        return unicode(self.course_id)
 
     def student_submission_id(self, submission_id=None):
         # pylint: disable=no-member


### PR DESCRIPTION
Due to a recent Django Rest Framework to v3.6.3 (old version was v3.2.3), the DRF serializers are now more strict. If a non-string is sent to a Django CharField field, the serializer marks the request as invalid. This issue is causing failures currently on edge.edx.org. Here's an example backtrace:
```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 116, in get
    return self._get(request)
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 153, in _get
    return render_to_response('courseware/courseware.html', self._create_courseware_context(request))
  File "/edx/app/edxapp/edx-platform/lms/djangoapps/courseware/views/index.py", line 400, in _create_courseware_context
    courseware_context['fragment'] = self.section.render(STUDENT_VIEW, section_context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1894, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1302, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 808, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 233, in student_view
    return self._student_view(context, banner_text)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 306, in _student_view
    'items': self._render_student_view_for_items(context, display_items, fragment),
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/seq_module.py", line 355, in _render_student_view_for_items
    rendered_item = item.render(STUDENT_VIEW, context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1894, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1302, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 808, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/vertical_block.py", line 65, in student_view
    rendered_child = child.render(STUDENT_VIEW, child_context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/core.py", line 202, in render
    return self.runtime.render(self, view, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1894, in render
    return self.__getattr__('render')(block, view_name, context)
  File "/edx/app/edxapp/edx-platform/common/lib/xmodule/xmodule/x_module.py", line 1302, in render
    return super(MetricsMixin, self).render(block, view_name, context=context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/xblock/runtime.py", line 808, in render
    frag = view_fn(context)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 198, in student_view
    "student_state": json.dumps(self.student_state()),
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 240, in student_state
    submission = self.get_submission()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/sga.py", line 168, in get_submission
    self.student_submission_id(submission_id))
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/submissions/api.py", line 364, in get_submissions
    student_item_model = _get_or_create_student_item(student_item_dict)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/submissions/api.py", line 1000, in _get_or_create_student_item
    raise SubmissionRequestError(field_errors=student_item_serializer.errors)
SubmissionRequestError: ('', {'course_id': [u'Not a valid string.'], 'item_id': [u'Not a valid string.']})
```

This change ensures that both item_id and course_id are properly serialized before sending them to the submission API.

@pdpinch FYI.