### PR TITLE
Release 0.6.4

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,11 @@
 Release Notes
 =============
 
+Version 0.6.4
+-------------
+
+- Serialize block/course locators before sending to submissions API. (#166)
+
 Version 0.6.3
 -------------
 

--- a/edx_sga/__init__.py
+++ b/edx_sga/__init__.py
@@ -2,4 +2,4 @@
 Module for StaffGradedAssignmentXBlock.
 """
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -140,7 +140,14 @@ class StaffGradedAssignmentXBlock(XBlock):
         """
         Return the usage_id of the block.
         """
-        return self.scope_ids.usage_id
+        return unicode(self.scope_ids.usage_id)
+
+    @reify
+    def block_course_id(self):
+        """
+        Return the course_id of the block.
+        """
+        return unicode(self.course_id)
 
     def student_submission_id(self, submission_id=None):
         # pylint: disable=no-member
@@ -155,9 +162,9 @@ class StaffGradedAssignmentXBlock(XBlock):
             )
         return {
             "student_id": submission_id,
-            "course_id": self.course_id,
+            "course_id": self.block_course_id,
             "item_id": self.block_id,
-            "item_type": 'sga',  # ???
+            "item_type": 'sga',
         }
 
     def get_submission(self, submission_id=None):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='edx-sga',
-    version='0.6.3',
+    version='0.6.4',
     description='edx-sga Staff Graded Assignment XBlock',
     license='Affero GNU General Public License v3 (GPLv3)',
     url="https://github.com/mitodl/edx-sga",


### PR DESCRIPTION
## John Eskew
  - [x] Serialize block/course locators before sending to submissions API. (#166) ([2910795c](../commit/2910795c59752741c700d983e9730a58c871e384))