### PR TITLE
Use the timezone of the platform as opposed to UTC for submissions' dates

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -719,7 +719,7 @@ def _now():
     """
     Get current date and time.
     """
-    return datetime.datetime.utcnow().replace(tzinfo=pytz.utc)
+    return datetime.datetime.utcnow().replace(tzinfo=pytz.timezone(settings.TIME_ZONE))
 
 
 def load_resource(resource_path):  # pragma: NO COVER

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -719,7 +719,8 @@ def _now():
     """
     Get current date and time.
     """
-    return datetime.datetime.utcnow().replace(tzinfo=pytz.timezone(settings.TIME_ZONE))
+    return datetime.datetime.utcnow().replace(tzinfo=pytz.timezone(getattr(settings, "TIME_ZONE", pytz.utc.zone)))
+
 
 
 def load_resource(resource_path):  # pragma: NO COVER


### PR DESCRIPTION
By default, the timezone of the submitted files is UTC.

If the admin of the platform has specified a different timezone in lms.env.json, then that timezone should also show up in the submitted files' upload dates.

Do you agree?

Thanks!