### PR TITLE
Release 0.7.1

### DIFF
--- a/RELEASE.rst
+++ b/RELEASE.rst
@@ -1,6 +1,18 @@
 Release Notes
 =============
 
+Version 0.7.1
+-------------
+
+- Reference __init__ version (#180)
+- Release 0.7.0
+- Added new tests with mocking data (#174)
+- Changed ugettext to ugettext_lazy (#178)
+- Replace hard coded strings to be translatable in the future (i10n) (#175)
+- Converted SGA into django app and added tox base testing (#170)
+- Use the timezone of the platform as opposed to UTC for submissions&#39; dates (#169)
+- Increase the height of the &quot;Select a File&quot; element (#165)
+
 Version 0.7.0
 -------------
 

--- a/edx_sga/__init__.py
+++ b/edx_sga/__init__.py
@@ -2,4 +2,4 @@
 Module for StaffGradedAssignmentXBlock.
 """
 
-__version__ = "0.6.4"
+__version__ = '0.7.1'

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 import os
 from setuptools import setup, find_packages
 
+import edx_sga
+
 
 def package_data(pkg, root_list):
     """Generic function to find package_data for `pkg` under `root`."""
@@ -16,7 +18,7 @@ def package_data(pkg, root_list):
 
 setup(
     name='edx-sga',
-    version='0.6.4',
+    version=edx_sga.__version__,
     description='edx-sga Staff Graded Assignment XBlock',
     license='Affero GNU General Public License v3 (GPLv3)',
     url="https://github.com/mitodl/edx-sga",


### PR DESCRIPTION
## George Schneeloch
  - [ ] Reference __init__ version (#180) ([b29b7270](../commit/b29b72708f922e6c87fff6723a5b84d1c1a6a66e))
  - [ ] Release 0.7.0 ([ffe569b6](../commit/ffe569b64744917fc6f321c2eca9a289c0173749))

## Amir Qayyum Khan
  - [ ] Added new tests with mocking data (#174) ([a9077a5d](../commit/a9077a5dab71c83fa271f8d93a66b1e7e47b7b52))
  - [ ] Changed ugettext to ugettext_lazy (#178) ([65e22fcb](../commit/65e22fcbb17ddf01bf5f28bc6b2c5f0bdc457e55))
  - [ ] Converted SGA into django app and added tox base testing (#170) ([ce220387](../commit/ce2203872d573b0992e423f43e0d63e9e4fd78c4))

## Mahyar Damavand
  - [ ] Replace hard coded strings to be translatable in the future (i10n) (#175) ([64ce4908](../commit/64ce4908ccb60c127df48d4e3d489f857711c96d))

## Miguel Amigot
  - [ ] Use the timezone of the platform as opposed to UTC for submissions&#39; dates (#169) ([9a97d3f0](../commit/9a97d3f0f98819aee3e6ea249c28f6d3356e03f5))
  - [ ] Increase the height of the &quot;Select a File&quot; element (#165) ([80c74629](../commit/80c74629611a4b643d8963a3ceecbee68f89f636))