### PR TITLE
Revert xblock-utils library

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ setup(
     include_package_data=True,
     install_requires=[
         'XBlock',
-        'mitodl_xblock_utils==1.0.5',
+        'xblock-utils==1.0.5',
     ],
     dependency_links=[
-        'https://github.com/mitodl/xblock-utils/tarball/master#egg=mitodl_xblock_utils-1.0.5'
+        'https://github.com/mitodl/xblock-utils/tarball/master#egg=xblock-utils-1.0.6'
     ],
     entry_points={
         'xblock.v1': [

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,6 @@ setup(
     include_package_data=True,
     install_requires=[
         'XBlock',
-        'xblock-utils==1.0.5',
-    ],
-    dependency_links=[
-        'https://github.com/mitodl/xblock-utils/tarball/master#egg=xblock-utils-1.0.6'
     ],
     entry_points={
         'xblock.v1': [


### PR DESCRIPTION
The egg was misnamed and I'm not sure how `--process-dependency-links` works with edx, so I'm reverting it for this PR and adding it back with everything else in a future PR once I've figured these things out