### PR TITLE
Integrate ShowAnswerXBlockMixin

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -37,6 +37,7 @@ from xblock.exceptions import JsonHandlerError  # lint-amnesty, pylint: disable=
 from xblock.fields import DateTime, Scope, String, Float, Integer  # lint-amnesty, pylint: disable=import-error
 from xblock.fragment import Fragment  # lint-amnesty, pylint: disable=import-error
 from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xblockutils.show_answers import ShowAnswerXBlockMixin
 
 from xmodule.util.duedate import get_extended_due_date  # lint-amnesty, pylint: disable=import-error
 
@@ -71,7 +72,7 @@ def reify(meth):
     return property(getter)
 
 
-class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, XBlock):
+class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMixin, XBlock):
     """
     This block defines a Staff Graded Assignment.  Students are shown a rubric
     and invited to upload a file which is then graded by staff.
@@ -79,7 +80,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, XBlock):
     has_score = True
     icon_class = 'problem'
     STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
-    editable_fields = ('display_name', 'points', 'weight')
+    editable_fields = ('display_name', 'points', 'weight', 'showanswer', 'solution')
 
     display_name = String(
         display_name=_("Display Name"),
@@ -294,7 +295,8 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, XBlock):
             "annotated": annotated,
             "graded": graded,
             "max_score": self.max_score(),
-            "upload_allowed": self.upload_allowed(submission_data=submission)
+            "upload_allowed": self.upload_allowed(submission_data=submission),
+            "solution": force_text(self.solution) if self.answer_available() else '',
         }
 
     def staff_grading_data(self):
@@ -469,7 +471,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, XBlock):
             submission.answer['finalized'] = True
             submission.submitted_at = django_now()
             submission.save()
-        return Response(json_body={})
+        return Response(json_body=self.student_state())
 
     @XBlock.handler
     def staff_upload_annotated(self, request, suffix=''):
@@ -842,6 +844,45 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, XBlock):
     def get_real_user(self):
         """returns session user"""
         return self.runtime.get_real_user(self.xmodule_runtime.anonymous_student_id)
+
+    def correctness_available(self):
+        """
+        For SGA is_correct just means the user submitted the problem, which we always know one way or the other
+        """
+        return True
+
+    def is_past_due(self):
+        """
+        Is it now past this problem's due date?
+        """
+        return self.past_due()
+
+    def is_correct(self):
+        """
+        For SGA we show the answer as soon as we know the user has given us their submission
+        """
+        return self.has_attempted()
+
+    def has_attempted(self):
+        """
+        True if the student has already attempted this problem
+        """
+        submission = self.get_submission()
+        if not submission:
+            return False
+        return submission['answer']['finalized']
+
+    def can_attempt(self):
+        """
+        True if the student can attempt the problem
+        """
+        return not self.has_attempted()
+
+    def runtime_user_is_staff(self):
+        """
+        Is the logged in user a staff user?
+        """
+        return self.is_course_staff()
 
 
 def _get_sha1(file_descriptor):

--- a/edx_sga/static/css/edx_sga.css
+++ b/edx_sga/static/css/edx_sga.css
@@ -111,6 +111,11 @@
   color: #0075b4;
 }
 
+.sga-block .solution::before {
+  content: "Solution: ";
+  font-weight: bold;
+}
+
 .staff-modal .task-message {
   font-family:'Open Sans', sans-serif;
   color: #4c4c4c;

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -35,8 +35,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
 
             $(content).find('.finalize-upload').on('click', function() {
               $.post(finalizeUploadUrl).success(
-                  function () {
-                      state.upload_allowed = false;
+                  function (state) {
                       render(state);
                   }
               ).fail(

--- a/edx_sga/templates/staff_graded_assignment/show.html
+++ b/edx_sga/templates/staff_graded_assignment/show.html
@@ -47,6 +47,11 @@
         <% } %>
       </div>
     <% } %>
+    <% if (solution) { %>
+      <div class="solution">
+        <%= solution %>
+      </div>
+    <% } %>
     <% if (error) { %>
       <p class="error"><%= error %></p>
     <% } %>

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -29,8 +29,8 @@ pip install --exists-action w -r requirements/edx/testing.txt
 if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
 
 cd /edx-sga
-pip uninstall edx-sga -y
-pip install -e .
+pip uninstall edx-sga xblock-utils -y
+pip install -e . --process-dependency-links
 cp /edx-sga/edx_sga /edx/app/edxapp/edx-platform/lms/djangoapps/ -r
 
 # output the packages which are installed for logging


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #185 

#### What's this PR do?
Adds `showanswer` and `solution` fields and uses `answer_available` to determine whether to show the solution. 

#### How should this be manually tested?
 - As staff create a new SGA block. Set showanswer to 'Attempted' and fill in some solution.
 - Save, then you should see the solution in the view immediately.
 - Log in as a student and view the SGA. You should not see the solution.
 - Upload something. You should not see the solution.
 - Click 'submit'. You should now see the solution.
