### PR TITLE
Fixed submission download bug

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -2,7 +2,7 @@
 This block defines a Staff Graded Assignment.  Students are shown a rubric
 and invited to upload a file which is then graded by staff.
 """
-import datetime
+from datetime import datetime
 import hashlib
 import json
 import logging
@@ -626,7 +626,7 @@ class StaffGradedAssignmentXBlock(XBlock):
             destination_path = get_zip_file_path(
                 user.username,
                 self.block_course_id,
-                unicode(self.block_id),
+                self.block_id,
                 self.location
             )
             zip_file_name = os.path.basename(destination_path)
@@ -717,7 +717,11 @@ class StaffGradedAssignmentXBlock(XBlock):
         """
         require(self.is_course_staff())
         student_id = request.params['student_id']
-        submissions_api.reset_score(student_id, unicode(self.course_id), unicode(self.block_id))
+        submissions_api.reset_score(
+            student_id,
+            self.block_course_id,
+            self.block_id
+        )
         module = self.get_module_by_id(request.params['module_id'])
         state = json.loads(module.state)
         state['staff_score'] = None
@@ -746,27 +750,30 @@ class StaffGradedAssignmentXBlock(XBlock):
         require(user)
         zip_file_ready = False
 
-        if self.is_zip_file_available():
+        if self.is_zip_file_available(user):
             assignments = self.get_sorted_submissions()
             if assignments:
-                last_assignment_date = assignments[0]['timestamp'].replace(tzinfo=pytz.utc)
+                last_assignment_date = assignments[0]['timestamp'].astimezone(pytz.utc)
                 zip_loc = get_zip_file_path(
                     user.username,
                     self.block_course_id,
-                    unicode(self.block_id),
+                    self.block_id,
                     self.location
                 )
-                zip_file_time = datetime.datetime.fromtimestamp(os.path.getmtime(zip_loc))
+                zip_file_time = datetime.fromtimestamp(
+                    os.path.getmtime(zip_loc),
+                    tz=pytz.utc
+                )
                 # if last zip file is older the last submission then recreate task
-                if zip_file_time >= last_assignment_date.replace(tzinfo=None):
+                if zip_file_time >= last_assignment_date:
                     zip_file_ready = True
 
         if not zip_file_ready:
             zip_student_submissions.delay(
                 self.block_course_id,
                 self.block_id,
-                self.location,
-                user
+                unicode(self.location),
+                user.username
             )
 
         return Response(json_body={
@@ -787,9 +794,11 @@ class StaffGradedAssignmentXBlock(XBlock):
         returns True if zip file is available for download
         """
         require(self.is_course_staff())
+        user = self.get_real_user()
+        require(user)
         return Response(
             json_body={
-                "zip_available": self.is_zip_file_available()
+                "zip_available": self.is_zip_file_available(user)
             }
         )
 
@@ -851,16 +860,14 @@ class StaffGradedAssignmentXBlock(XBlock):
         )
         return path
 
-    def is_zip_file_available(self):
+    def is_zip_file_available(self, user):
         """
-        returns True if zip file available.
+        returns True if zip file exists.
         """
-        user = self.get_real_user()
-        require(user)
         zip_file_path = get_zip_file_path(
             user.username,
             self.block_course_id,
-            unicode(self.block_id),
+            self.block_id,
             self.location
         )
         return True if os.path.exists(zip_file_path) else False

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -328,8 +328,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                 $(element).find('#download-init-button').click(function(e) {
                   e.preventDefault();
                   var self = this;
-                  $.get(
-                    prepareDownloadSubmissionsUrl,
+                  $.get(prepareDownloadSubmissionsUrl).then(
                     function(data) {
                       if (data["downloadable"]) {
                         window.location = downloadSubmissionsUrl;
@@ -343,6 +342,15 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                           .addClass("preparing-msg");
                         pollSubmissionDownload();
                       }
+                    }
+                  ).fail(
+                    function() {
+                      $(self).removeClass("disabled");
+                      $(element).find('.task-message')
+                        .show()
+                        .html(gettext("An error occurred while trying to prepare your submission file"))
+                        .removeClass("preparing-msg")
+                        .addClass("ready-msg");
                     }
                   );
                 });

--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -11,30 +11,21 @@ from django.core.files.storage import default_storage  # lint-amnesty, pylint: d
 from lms import CELERY_APP  # pylint: disable=no-name-in-module, import-error
 from submissions import api as submissions_api  # lint-amnesty, pylint: disable=import-error
 from student.models import user_by_anonymous_id  # lint-amnesty, pylint: disable=import-error
+from opaque_keys.edx.locator import BlockUsageLocator
+
 
 log = logging.getLogger(__name__)
 DATA_DIR = getattr(settings, "DATA_DIR", "/edx/app/edxapp/data")
 
 
-def _rm_file(path):
-    """
-    Removes file if it exist.
-
-    Args:
-        path (str): path of new directory
-    """
-    if os.path.exists(path):
-        rmtree(path)
-
-
-def _collect_student_submissions(block_id, course_id, location, destination_path):
+def _collect_student_submissions(block_id, course_id, locator, destination_path):
     """
     prepare files for download
 
     Args:
         course_id (unicode): edx course id
         block_id (unicode): edx block id
-        location (Location): location of sga module
+        locator (BlockUsageLocator): BlockUsageLocator for the sga module
         destination_path (str): folder from where we will zip files and facilitate for download
     """
     from edx_sga.sga import BLOCK_SIZE, ITEM_TYPE
@@ -49,7 +40,7 @@ def _collect_student_submissions(block_id, course_id, location, destination_path
         if answer:
             student = user_by_anonymous_id(submission['student_id'])
             source_file = six.u('{loc.org}/{loc.course}/{loc.block_type}/{loc.block_id}/{sha1}{ext}').format(
-                loc=location,
+                loc=locator,
                 sha1=answer['sha1'],
                 ext=os.path.splitext(answer['filename'])[1]
             )
@@ -89,35 +80,35 @@ def _compress_folder(destination_path):
     )
 
 
-def _get_submissions_base_name(user_name, block_id, course_id):
+def _get_submissions_base_name(username, block_id, course_id):
     """
     returns submission folder name where we are saving files.
 
     Args:
         course_id (unicode): edx course id
         block_id (unicode): edx block id
-        user_name (unicode): staff user name
+        username (unicode): staff user name
     """
     return "{username}_submissions_{id}_{course_key}".format(
-        username=user_name,
+        username=username,
         id=hashlib.md5(block_id).hexdigest(),
         course_key=course_id
     )
 
 
-def _get_dir_path(submissions_dir_name, location=None):
+def _get_dir_path(submissions_dir_name, locator=None):
     """
     returns directory path where we are saving files.
 
     Args:
         submissions_dir_name (str): name of folder
-        location (Location): location of sga module
+        locator (BlockUsageLocator): BlockUsageLocator for the sga module
     """
-    if location:
+    if locator:
         return os.path.join(
             DATA_DIR,
             "{loc.org}/{loc.course}/{loc.run}/{submissions_dir_name}".format(
-                loc=location,
+                loc=locator,
                 submissions_dir_name=submissions_dir_name
             )
         )
@@ -132,43 +123,47 @@ def _remove_existing_artifacts(destination_path):
     Args:
         destination_path (str): folder from where we will zip files and facilitate for download
     """
-    _rm_file(destination_path)
-    _rm_file("{}.zip".format(destination_path))  # remove existing zip file
+    if os.path.exists(destination_path):
+        rmtree(destination_path)
+    zip_file_path = "{}.zip".format(destination_path)
+    if os.path.exists(zip_file_path):
+        os.remove(zip_file_path)
 
 
 @CELERY_APP.task
-def zip_student_submissions(course_id, block_id, location, user):
+def zip_student_submissions(course_id, block_id, locator_unicode, username):
     """
     Task to download all submissions as zip file
 
     Args:
         course_id (unicode): edx course id
         block_id (unicode): edx block id
-        location (Location): location of sga module
-        user_name (str): staff user name
+        locator_unicode (unicode): Unicode representing a BlockUsageLocator for the sga module
+        username (unicode): staff user name
     """
-    submissions_dir_name = _get_submissions_base_name(user.username, block_id, course_id)
-    destination_path = _get_dir_path(submissions_dir_name, location)
+    locator = BlockUsageLocator.from_string(locator_unicode)
+    submissions_dir_name = _get_submissions_base_name(username, block_id, course_id)
+    destination_path = _get_dir_path(submissions_dir_name, locator)
     _remove_existing_artifacts(destination_path)
     os.mkdir(destination_path)
-    _collect_student_submissions(block_id, course_id, location, destination_path)
+    _collect_student_submissions(block_id, course_id, locator, destination_path)
     _compress_folder(destination_path)
 
 
-def get_zip_file_name(user_name, block_id, course_id):
+def get_zip_file_name(username, block_id, course_id):
     """
     returns submission folder name where we are saving files temporary.
 
     Args:
         course_id (unicode): edx course id
         block_id (unicode): edx block id
-        user_name (unicode): staff user name
+        username (unicode): staff user name
     """
-    submissions_dir_name = _get_submissions_base_name(user_name, block_id, course_id)
+    submissions_dir_name = _get_submissions_base_name(username, block_id, course_id)
     return "{}.zip".format(submissions_dir_name)
 
 
-def get_zip_file_path(username, course_id, block_id, location):
+def get_zip_file_path(username, course_id, block_id, locator):
     """
     returns zip file path.
 
@@ -176,7 +171,7 @@ def get_zip_file_path(username, course_id, block_id, location):
         username (unicode): user name
         course_id (unicode): edx course id
         block_id (unicode): edx block id
-        location (Location): location of sga module
+        locator (BlockUsageLocator): BlockUsageLocator for the sga module
     """
     return _get_dir_path(
         get_zip_file_name(
@@ -184,5 +179,5 @@ def get_zip_file_path(username, course_id, block_id, location):
             block_id,
             course_id
         ),
-        location
+        locator
     )

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -728,7 +728,7 @@ class StaffGradedAssignmentMockedTests(unittest.TestCase):
             {
                 'submission_id': uuid.uuid4().hex,
                 'filename': "test_{}.txt".format(uuid.uuid4().hex),
-                'timestamp': datetime.datetime.utcnow()
+                'timestamp': datetime.datetime.now(tz=pytz.utc)
             } for __ in range(2)
         ]
         zip_student_submissions.delay = mock.Mock()
@@ -780,10 +780,10 @@ class StaffGradedAssignmentMockedTests(unittest.TestCase):
             assert response_body["downloadable"] is False
 
         zip_student_submissions.delay.assert_called_with(
-            block.block_course_id,
-            block.block_id,
-            block.location,
-            self.staff
+            unicode(block.block_course_id),
+            unicode(block.block_id),
+            unicode(block.location),
+            self.staff.username
         )
 
     @data((False, False), (True, True))


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #195 

#### What's this PR do?
Fixes the 500 error we were seeing in QA for submission downloads, and addresses a couple other potential bugs

#### How should this be manually tested?
Use the "Download All Submissions" button in the "Grade Submissions" modal

#### Any background context you want to provide?
This was not caught because of the familiar `CELERY_ALWAYS_EAGER` behavior that is the default for our development machines. When I ran my devstack with `CELERY_ALWAYS_EAGER=False`, I also noticed a couple other buggy behaviors that were not happening in previous runs (maybe because of the `CELERY_ALWAYS_EAGER` change, maybe not):

1. The zip files that were being created in my devstack filesystem appeared to be in UTC time when looking at them with `ls -al`, but `datetime.datetime.fromtimestamp` was returning a timestamp for the file in local time. This caused an issue because the submission `submitted_at` time is set to UTC, so if I had a submission with a `submitted_at` time 5 minutes older than the zip file creation time, it would be actually be considered 4 hours and 50 minutes more recent. I changed the logic to coerce both timestamps to UTC for comparison.
1. We were using [shutils.rmtree](https://docs.python.org/2/library/shutil.html#shutil.rmtree) to delete a directory and a file, but with `CELERY_ALWAYS_EAGER=False`, an exception was raised when trying to remove the file. If you look at the docs, it seems that it's supposed to be used for directories only. I don't know why this worked before, but I changed the file deletion function to [os.remove](https://docs.python.org/2/library/os.html#os.remove)

