### PR TITLE
Use UTC for timestamp

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -46,7 +46,7 @@ from edx_sga.tasks import (
     zip_student_submissions
 )
 from edx_sga.utils import (
-    tznow,
+    utcnow,
     is_finalized_submission
 )
 
@@ -237,7 +237,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         state['annotated_sha1'] = sha1 = _get_sha1(upload.file)
         state['annotated_filename'] = filename = upload.file.name
         state['annotated_mimetype'] = mimetypes.guess_type(upload.file.name)[0]
-        state['annotated_timestamp'] = tznow().strftime(
+        state['annotated_timestamp'] = utcnow().strftime(
             DateTime.DATETIME_FORMAT
         )
         path = self.file_storage_path(sha1, filename)
@@ -596,7 +596,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         Add context info for the Staff Debug interface.
         """
         published = self.start
-        context['is_released'] = published and published < tznow()
+        context['is_released'] = published and published < utcnow()
         context['location'] = self.location
         context['category'] = type(self).__name__
         context['fields'] = [
@@ -606,6 +606,12 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
     def get_module_by_id(self, module_id):
         """
         returns student mode object
+
+        Args:
+            module_id (int): The module id
+
+        Returns:
+            StudentModule: A StudentModule object
         """
         return StudentModule.objects.get(pk=module_id)
 
@@ -799,7 +805,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         """
         due = get_extended_due_date(self)
         if due is not None:
-            return tznow() > due
+            return utcnow() > due
         return False
 
     def upload_allowed(self, submission_data=None):

--- a/edx_sga/tests/common.py
+++ b/edx_sga/tests/common.py
@@ -1,10 +1,14 @@
 """shared test data"""
 from contextlib import contextmanager
+from datetime import datetime
+import hashlib
 import os
 import shutil
 from tempfile import mkdtemp
 
 from mock import Mock
+import pytz
+from xblock.fields import DateTime
 
 
 class DummyResource(object):
@@ -41,3 +45,29 @@ def dummy_upload(filename):
             yield Mock(file=f), data
     finally:
         shutil.rmtree(directory)
+
+
+def get_sha1(data):
+    """
+    Helper function to produce a SHA1 hash
+    """
+    algorithm = hashlib.sha1()
+    algorithm.update(data)
+    return algorithm.hexdigest()
+
+
+def is_near_now(other_time):
+    """
+    Is a time pretty close to right now?
+    """
+    delta = abs(other_time - datetime.now(tz=pytz.utc))
+    return delta.total_seconds() < 5
+
+
+def parse_timestamp(timestamp):
+    """
+    Parse the xblock timestamp into a UTC datetime
+    """
+    return datetime.strptime(timestamp, DateTime.DATETIME_FORMAT).replace(
+        tzinfo=pytz.utc
+    )

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -3,6 +3,7 @@
 Tests for SGA
 """
 import datetime
+import hashlib
 import json
 import tempfile
 from ddt import ddt, data  # pylint: disable=import-error
@@ -26,7 +27,13 @@ from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-a
 from opaque_keys.edx.locations import Location  # lint-amnesty, pylint: disable=import-error
 
 from edx_sga.sga import StaffGradedAssignmentXBlock
-from edx_sga.tests.common import DummyResource, dummy_upload
+from edx_sga.tests.common import (
+    DummyResource,
+    dummy_upload,
+    get_sha1,
+    is_near_now,
+    parse_timestamp,
+)
 
 
 @ddt
@@ -418,6 +425,32 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
             )
             self.assertEqual(response.status_code, 404)
 
+    def test_staff_upload_annotated_state(self):
+        # pylint: disable=no-member
+        """
+        Test state recorded in the module state when staff_upload_annotated is called
+        """
+        block = self.make_one()
+        fred = self.make_student(block, "fred1")['module']
+
+        with dummy_upload('testa.txt') as (upload, _):
+            block.upload_assignment(mock.Mock(params={"assignment": upload}))
+        block.finalize_uploaded_assignment(mock.Mock(method="POST"))
+
+        with dummy_upload('testb.txt') as (upload, expected):
+            request = mock.Mock(params={
+                'annotated': upload,
+                'module_id': fred.id
+            })
+            resp = block.staff_upload_annotated(request)
+        assert resp.json == block.staff_grading_data()
+        state = json.loads(block.get_module_by_id(fred.id).state)
+        assert state['annotated_mimetype'] == 'text/plain'
+        parsed_date = parse_timestamp(state['annotated_timestamp'])
+        assert is_near_now(parsed_date)
+        assert state['annotated_filename'].endswith('testb.txt')
+        assert state['annotated_sha1'] == get_sha1(expected)
+
     def test_download_annotated(self):
         # pylint: disable=no-member
         """
@@ -546,27 +579,44 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
             filename="foo.txt",
             score=10,
             annotated_filename="foo_corrected.txt",
-            comment="Good work!")['module']
+            comment="Good work!")
         fred = self.make_student(
             block, "fred",
-            filename="bar.txt")['module']
+            filename="bar.txt")
         data = block.get_staff_grading_data(None).json_body  # lint-amnesty, pylint: disable=redefined-outer-name
         assignments = sorted(data['assignments'], key=lambda x: x['username'])
-        self.assertEqual(assignments[0]['module_id'], barney.id)
-        self.assertEqual(assignments[0]['username'], 'barney')
-        self.assertEqual(assignments[0]['fullname'], 'barney')
-        self.assertEqual(assignments[0]['filename'], 'foo.txt')
-        self.assertEqual(assignments[0]['score'], 10)
-        self.assertEqual(assignments[0]['annotated'], 'foo_corrected.txt')
-        self.assertEqual(assignments[0]['comment'], 'Good work!')
 
-        self.assertEqual(assignments[1]['module_id'], fred.id)
-        self.assertEqual(assignments[1]['username'], 'fred')
-        self.assertEqual(assignments[1]['fullname'], 'fred')
-        self.assertEqual(assignments[1]['filename'], 'bar.txt')
-        self.assertEqual(assignments[1]['score'], None)
-        self.assertEqual(assignments[1]['annotated'], u'')
-        self.assertEqual(assignments[1]['comment'], u'')
+        barney_assignment, fred_assignment = assignments
+
+        assert barney_assignment['module_id'] == barney['module'].id
+        assert barney_assignment['username'] == 'barney'
+        assert barney_assignment['fullname'] == 'barney'
+        assert barney_assignment['filename'] == 'foo.txt'
+        assert barney_assignment['score'] == 10
+        assert barney_assignment['annotated'] == 'foo_corrected.txt'
+        assert barney_assignment['comment'] == 'Good work!'
+        assert barney_assignment['approved'] is True
+        assert barney_assignment['finalized'] is True
+        assert barney_assignment['may_grade'] is False
+        assert barney_assignment['needs_approval'] is False
+        assert barney_assignment['student_id'] == barney['item'].student_id
+        assert barney_assignment['submission_id'] == barney['submission']['uuid']
+        assert is_near_now(parse_timestamp(barney_assignment['timestamp']))
+
+        assert fred_assignment['module_id'] == fred['module'].id
+        assert fred_assignment['username'] == 'fred'
+        assert fred_assignment['fullname'] == 'fred'
+        assert fred_assignment['filename'] == 'bar.txt'
+        assert fred_assignment['score'] is None
+        assert fred_assignment['annotated'] == u''
+        assert fred_assignment['comment'] == u''
+        assert fred_assignment['approved'] is False
+        assert fred_assignment['finalized'] is True
+        assert fred_assignment['may_grade'] is True
+        assert fred_assignment['needs_approval'] is False
+        assert fred_assignment['student_id'] == fred['item'].student_id
+        assert fred_assignment['submission_id'] == fred['submission']['uuid']
+        assert is_near_now(parse_timestamp(fred_assignment['timestamp']))
 
     @mock.patch('edx_sga.sga.log')
     def test_assert_logging_when_student_module_created(self, mocked_log):

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -3,7 +3,6 @@
 Tests for SGA
 """
 import datetime
-import hashlib
 import json
 import tempfile
 from ddt import ddt, data  # pylint: disable=import-error

--- a/edx_sga/tests/test_utils.py
+++ b/edx_sga/tests/test_utils.py
@@ -3,7 +3,13 @@
 Tests for SGA utility functions
 """
 import pytest  # pylint: disable=import-error
-from edx_sga.utils import is_finalized_submission
+import pytz
+
+from edx_sga.utils import (
+    is_finalized_submission,
+    utcnow,
+)
+from edx_sga.tests.common import is_near_now
 
 
 @pytest.mark.parametrize(
@@ -19,3 +25,12 @@ from edx_sga.utils import is_finalized_submission
 def test_is_finalized_submission(submission_data, expected_value):
     """Test for is_finalized_submission"""
     assert is_finalized_submission(submission_data) is expected_value
+
+
+def test_utcnow():
+    """
+    tznow should return a datetime object in UTC
+    """
+    now = utcnow()
+    assert is_near_now(now)
+    assert now.tzinfo.zone == pytz.utc.zone

--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -4,23 +4,12 @@ Utility functions for the SGA XBlock
 import datetime
 import pytz
 
-from django.conf import settings
 
-
-def get_time_zone():
+def utcnow():
     """
-    returns user preferred time zone
+    Get current date and time in UTC
     """
-    return pytz.timezone(getattr(settings, "TIME_ZONE", pytz.utc.zone))
-
-
-def tznow():
-    """
-    Get current date and time.
-    """
-    return datetime.datetime.utcnow().replace(
-        tzinfo=get_time_zone()
-    )
+    return datetime.datetime.now(tz=pytz.utc)
 
 
 def is_finalized_submission(submission_data):


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #204 

#### What's this PR do?
Since the XBlock field assumes UTC formatted timestamps we should store our timestamps in that format. Tests are also added

#### How should this be manually tested?
Tests should pass