### PR TITLE
Add handling for grace period

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -804,8 +804,20 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         Return whether due date has passed.
         """
         due = get_extended_due_date(self)
-        if due is not None:
-            return utcnow() > due
+        try:
+            graceperiod = self.graceperiod
+        except AttributeError:
+            # graceperiod and due are defined in InheritanceMixin
+            # It's used automatically in edX but the unit tests will need to mock it out
+            graceperiod = None
+
+        if graceperiod is not None and due:
+            close_date = due + graceperiod
+        else:
+            close_date = due
+
+        if close_date is not None:
+            return utcnow() > close_date
         return False
 
     def upload_allowed(self, submission_data=None):

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -790,3 +790,14 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
         )
         block = self.make_one()
         assert block.runtime_user_is_staff() is is_staff
+
+    @data(True, False)
+    def test_grace_period(self, has_grace_period):
+        block = self.make_one()
+
+        # Due date is slightly in the past
+        block.due = datetime.datetime.now(tz=pytz.utc) - datetime.timedelta(seconds=500)
+        if has_grace_period:
+            block.graceperiod = datetime.timedelta(days=1)
+
+        assert block.past_due() is not has_grace_period


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #183 

#### What's this PR do?
Adds support for course grace periods

#### How should this be manually tested?
 - Install this version of SGA and create a course with an SGA
 - In studio, click on the settings icon for the subsection for the SGA. Set the course due date to yesterday
 - View the SGA unit as a student. You should not see an upload button.
 - In studio go to Settings -> Grading. Set the grace period to 48 hours (`48:00`).
 - View the SGA unit as a student. You should see an upload button.