### PR TITLE
Replace static links when rendering solution text

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -40,6 +40,7 @@ from xblock.fragment import Fragment  # lint-amnesty, pylint: disable=import-err
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 
 from xmodule.util.duedate import get_extended_due_date  # lint-amnesty, pylint: disable=import-error
+from xmodule.contentstore.content import StaticContent
 
 from edx_sga.showanswer import ShowAnswerXBlockMixin
 from edx_sga.tasks import (
@@ -684,6 +685,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             "max_score": self.max_score(),
             "upload_allowed": self.upload_allowed(submission_data=submission),
             "solution": force_text(self.solution) if self.answer_available() else '',
+            "base_asset_url": StaticContent.get_base_url_path_for_course_assets(self.location.course_key),
         }
 
     def staff_grading_data(self):

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -24,11 +24,37 @@ function StaffGradedAssignmentXBlock(runtime, element) {
           'Started preparing student submissions zip file. This may take a while.'
         );
 
+        // Utility method for replacing a portion of a string.
+        // copied from edx-platform/common/static/js/src/utility.js
+        function rewriteStaticLinks(content, from, to) {
+            if (from === null || to === null) {
+                return content;
+            }
+            // replace only relative urls
+            function replacer(match) {
+                if (match === from) {
+                    return to;
+                } else {
+                    return match;
+                }
+            }
+
+            // change all relative urls only which may be embedded inside other tags in content.
+            // handle http and https
+            // escape all regex interpretable chars
+            var fromRe = from.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+            var regex = new RegExp('(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%_\+.~#?&//=]*))?' + fromRe, 'g');
+            return content.replace(regex, replacer);
+        }
+
         function render(state) {
             // Add download urls to template context
             state.downloadUrl = downloadUrl;
             state.annotatedUrl = annotatedUrl;
             state.error = state.error || false;
+            if (state.solution) {
+              state.solution = rewriteStaticLinks(state.solution, "/static/", state.base_asset_url);
+            }
 
             // Render template
             var content = $(element).find('#sga-content').html(template(state));

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -752,6 +752,13 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
         ):
             assert block.student_state()['solution'] == ('A solution' if is_answer_available else '')
 
+    def test_base_asset_url(self):
+        """
+        The base asset url for the course should be passed to the javascript so it can replace static links
+        """
+        block = self.make_one(solution='A solution')
+        assert block.student_state()['base_asset_url'] == '/c4x/foo/bar/asset/'
+
     def test_correctness_available(self):
         """
         Correctness should always be available


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #216 

#### What's this PR do?
Replaces `/static/...` links in the solution HTML with a link for the particular course asset

#### How should this be manually tested?
 - Create an SGA unit
 - Upload a PDF or some other kind of file under Contents -> Files and Uploads
 - Copy the link under `Studio:`, it should look something like `/static/test.pdf`. Add a link to that URL for the HTML for the solution of the SGA unit.
 - Click on the link in studio. You should be redirected to the file and be able to download it, but the link should look different from the `/static/test.pdf` link of before. 
 - Publish and changes and view the live version of the course. You should see the same link and it should have the same URL that you saw in Studio.

