### PR TITLE
Fixed file modified time calculation for submission zip file

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -49,7 +49,8 @@ from edx_sga.tasks import (
 )
 from edx_sga.utils import (
     utcnow,
-    is_finalized_submission
+    is_finalized_submission,
+    get_file_modified_time_utc
 )
 
 
@@ -453,21 +454,13 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             assignments = self.get_sorted_submissions()
             if assignments:
                 last_assignment_date = assignments[0]['timestamp'].astimezone(pytz.utc)
-                zip_loc = get_zip_file_path(
+                zip_file_path = get_zip_file_path(
                     user.username,
                     self.block_course_id,
                     self.block_id,
                     self.location
                 )
-
-                # modified_time returns local datetime object.
-                zip_file_time = (
-                    pytz.timezone(
-                        settings.TIME_ZONE
-                    ).localize(
-                        default_storage.modified_time(zip_loc)
-                    ).astimezone(pytz.utc)
-                )
+                zip_file_time = get_file_modified_time_utc(zip_file_path)
                 # if last zip file is older the last submission then recreate task
                 if zip_file_time >= last_assignment_date:
                     zip_file_ready = True

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -621,7 +621,7 @@ class StaffGradedAssignmentMockedTests(unittest.TestCase):
             'edx_sga.sga.StaffGradedAssignmentXBlock.get_real_user',
             return_value=self.staff
         ), mock.patch(
-            'edx_sga.sga.default_storage.modified_time',
+            'edx_sga.utils.default_storage.modified_time',
             return_value=datetime.datetime.now()
         ):
             response = block.prepare_download_submissions(None)

--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -2,7 +2,11 @@
 Utility functions for the SGA XBlock
 """
 import datetime
+import time
 import pytz
+
+from django.conf import settings
+from django.core.files.storage import default_storage
 
 
 def utcnow():
@@ -19,3 +23,21 @@ def is_finalized_submission(submission_data):
     if submission_data and submission_data.get('answer') is not None:
         return submission_data['answer'].get('finalized', True)
     return False
+
+
+def get_file_modified_time_utc(file_path):
+    """
+    Gets the UTC timezone-aware modified time of a file at the given file path
+    """
+    file_timezone = (
+        # time.tzname returns a 2 element tuple:
+        #   (local non-DST timezone, e.g.: 'EST', local DST timezone, e.g.: 'EDT')
+        pytz.timezone(time.tzname[0])
+        if settings.DEFAULT_FILE_STORAGE == 'django.core.files.storage.FileSystemStorage'
+        else pytz.utc
+    )
+    return file_timezone.localize(
+        default_storage.modified_time(file_path)
+    ).astimezone(
+        pytz.utc
+    )


### PR DESCRIPTION
#### What are the relevant tickets?
Closes https://github.com/mitodl/salt-ops/issues/504 (essentially)

#### What's this PR do?
Fixes the way that we calculate the file modified time for the student submissions zip file.

#### How should this be manually tested?
As some staff user, click "Download All Submissions" for some SGA problem, upload a new file from another user, then click "Download All Submissions" again with the original staff user. A new zip file should be created, and the downloaded file should contain all submissions
