### PR TITLE
Added logic to clear a user's state in the XBlock

### DIFF
--- a/edx_sga/templates/staff_graded_assignment/show.html
+++ b/edx_sga/templates/staff_graded_assignment/show.html
@@ -141,8 +141,6 @@
   <div aria-hidden="true" class="wrap-instructor-info">
     <a class="instructor-info-action" id="grade-submissions-button"
        href="#grade-{{ id }}">{% trans "Grade Submissions" %}</a>
-    <a class="instructor-info-action" id="staff-debug-info-button"
-       href="#debug-{{ id }}">{% trans "Staff Debug Info" %}</a>
   </div>
 
   <section aria-hidden="true" class="modal staff-modal" id="grade-{{ id }}" style="height: 75%" tabindex="-1">

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -452,7 +452,7 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
             })
             resp = block.staff_upload_annotated(request)
         assert resp.json == block.staff_grading_data()
-        state = json.loads(block.get_module_by_id(fred.id).state)
+        state = json.loads(block.get_student_module(fred.id).state)
         assert state['annotated_mimetype'] == 'text/plain'
         parsed_date = parse_timestamp(state['annotated_timestamp'])
         assert is_near_now(parsed_date)
@@ -642,12 +642,10 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
             comment="Good work!"
         )
         block.staff_grading_data()
-        mocked_log.info.assert_called_with(
-            "Init for course:%s module:%s student:%s  ",
-            block.course_id,
-            block.location,
-            'tester'
-        )
+        module_creation_log_message = mocked_log.info.call_args[0]
+        self.assertIn('tester', module_creation_log_message)
+        self.assertIn(block.course_id, module_creation_log_message)
+        self.assertIn(block.location, module_creation_log_message)
 
     def test_enter_grade_instructor(self):
         # pylint: disable=no-member

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -10,6 +10,7 @@ edx-opaque-keys==0.4
 edx-submissions==2.0.12
 mako==1.0.7
 mock==2.0.0
+pdbpp
 pep8==1.6.2
 pylint-django==0.7.2
 pyOpenSSL==17.3.0


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #214 

#### What's this PR do?
Clears submissions and uploaded files for a student in the given SGA XBlock if a staff user elects to delete their state

#### How should this be manually tested?
1. Log in as a non-staff user
1. Upload a file
1. Log in as a staff user
1. Navigate to the SGA and click "Staff Debug Info" 
1. Enter that first user's username and click "Delete Learner State"
1. Log in as the non-staff user, confirm that you don't see your uploaded file anymore
1. Upload another file as the non-staff user
1. Repeat steps 3-5 and confirm that you don't get an error after clicking "Delete Learner State"

#### Where should the reviewer start?
Probably `sga.py`

#### Any background context you want to provide?
Also got rid of the redundant Staff Debug Info
