### PR TITLE
Handle static_asset_path setting

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -678,6 +678,11 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         else:
             graded = None
 
+        if self.answer_available():
+            solution = self.runtime.replace_urls(force_text(self.solution))
+        else:
+            solution = ''
+
         return {
             "display_name": force_text(self.display_name),
             "uploaded": uploaded,
@@ -685,7 +690,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             "graded": graded,
             "max_score": self.max_score(),
             "upload_allowed": self.upload_allowed(submission_data=submission),
-            "solution": force_text(self.solution) if self.answer_available() else '',
+            "solution": solution,
             "base_asset_url": StaticContent.get_base_url_path_for_course_assets(self.location.course_key),
         }
 

--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -24,37 +24,11 @@ function StaffGradedAssignmentXBlock(runtime, element) {
           'Started preparing student submissions zip file. This may take a while.'
         );
 
-        // Utility method for replacing a portion of a string.
-        // copied from edx-platform/common/static/js/src/utility.js
-        function rewriteStaticLinks(content, from, to) {
-            if (from === null || to === null) {
-                return content;
-            }
-            // replace only relative urls
-            function replacer(match) {
-                if (match === from) {
-                    return to;
-                } else {
-                    return match;
-                }
-            }
-
-            // change all relative urls only which may be embedded inside other tags in content.
-            // handle http and https
-            // escape all regex interpretable chars
-            var fromRe = from.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-            var regex = new RegExp('(https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}([-a-zA-Z0-9@:%_\+.~#?&//=]*))?' + fromRe, 'g');
-            return content.replace(regex, replacer);
-        }
-
         function render(state) {
             // Add download urls to template context
             state.downloadUrl = downloadUrl;
             state.annotatedUrl = annotatedUrl;
             state.error = state.error || false;
-            if (state.solution) {
-              state.solution = rewriteStaticLinks(state.solution, "/static/", state.base_asset_url);
-            }
 
             // Render template
             var content = $(element).find('#sga-content').html(template(state));

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -25,6 +25,7 @@ from submissions.models import StudentItem  # lint-amnesty, pylint: disable=impo
 from student.models import anonymous_id_for_user, UserProfile  # lint-amnesty, pylint: disable=import-error
 from student.tests.factories import AdminFactory  # lint-amnesty, pylint: disable=import-error
 from xblock.field_data import DictFieldData
+from xblock.fields import ScopeIds
 from xmodule.modulestore.django import modulestore  # lint-amnesty, pylint: disable=import-error
 from xmodule.modulestore.tests.factories import CourseFactory, ItemFactory  # lint-amnesty, pylint: disable=import-error
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase  # lint-amnesty, pylint: disable=import-error
@@ -54,23 +55,13 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
         engine for use in all tests
         """
         super(StaffGradedAssignmentXblockTests, self).setUp()
-        course = CourseFactory.create(org='foo', number='bar', display_name='baz')
-        descriptor = ItemFactory(category="pure", parent=course)
-        self.course_id = course.id
+        self.course = CourseFactory.create(org='foo', number='bar', display_name='baz')
+        self.descriptor = ItemFactory(category="pure", parent=self.course)
+        self.course_id = self.course.id
         self.instructor = StaffFactory.create(course_key=self.course_id)
         self.student_data = mock.Mock()
-        self.runtime, _ = render.get_module_system_for_user(
-            self.instructor,
-            self.student_data,
-            descriptor,
-            course.id,
-            mock.Mock(),
-            mock.Mock(),
-            mock.Mock(),
-            course=course
-        )
-
-        self.scope_ids = mock.Mock()
+        self.runtime = self.make_runtime()
+        self.scope_ids = self.make_scope_ids(self.runtime)
 
         tmp = tempfile.mkdtemp()
         self.addCleanup(lambda: shutil.rmtree(tmp))
@@ -80,6 +71,38 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
         self.addCleanup(updated_settings_decorator.disable)
 
         self.staff = AdminFactory.create(password="test")
+
+    def make_runtime(self, **kwargs):
+        """
+        Make a runtime
+        """
+        runtime, _ = render.get_module_system_for_user(
+            self.instructor,
+            self.student_data,
+            self.descriptor,
+            self.course.id,
+            mock.Mock(),
+            mock.Mock(),
+            mock.Mock(),
+            course=self.course,
+            # not sure why this isn't working, if set to true it looks for
+            # 'display_name_with_default_escaped' field that doesn't exist in SGA
+            wrap_xmodule_display=False,
+            **kwargs
+        )
+
+        return runtime
+
+    def make_scope_ids(self, runtime):
+        """
+        Make scope ids
+        """
+        # Not sure if this is a valid block type, might be sufficient for testing purposes
+        block_type = 'sga'
+        def_id = runtime.id_generator.create_definition(block_type)
+        return ScopeIds(
+            'user', block_type, def_id, self.descriptor.location
+        )
 
     def make_one(self, display_name=None, **kw):
         """
@@ -93,7 +116,6 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
 
         block.xmodule_runtime = self.runtime
         block.course_id = self.course_id
-        block.scope_ids.usage_id = "i4x://foo/bar/category/name"
         block.category = 'problem'
 
         if display_name:
@@ -751,6 +773,27 @@ class StaffGradedAssignmentXblockTests(ModuleStoreTestCase):
             return_value=is_answer_available,
         ):
             assert block.student_state()['solution'] == ('A solution' if is_answer_available else '')
+
+    @data(True, False)
+    def test_replace_url(self, has_static_asset_path):
+        """
+        If the static asset path is set on a course, it should be substituted when the course is rendered
+        """
+        # make a runtime with a static asset path, which will override the base_asset_url
+
+        static_asset_path = '/a/different/static/asset/path'
+        if has_static_asset_path:
+            self.runtime = self.make_runtime(static_asset_path=static_asset_path)
+            self.scope_ids = self.make_scope_ids(self.runtime)
+
+        block = self.make_one(
+            solution='<a href="/static/test.pdf">A PDF</a>',
+            showanswer=ShowAnswer.ALWAYS,
+        )
+        solution = block.student_state()['solution']
+        assert '<a href="{}/test.pdf">A PDF</a>'.format(
+            static_asset_path if has_static_asset_path else '/c4x/foo/bar/asset'
+        ) == solution
 
     def test_base_asset_url(self):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #220 

#### What's this PR do?
Removes decoy front end link replacement, uses the runtime's replace_url function to do it instead. Unlike `HtmlModule` this function is used on the solution directly in `student_state()` so we should be able to keep the same rendering logic as before, where the solution is updated right after the student submits their answer.

#### How should this be manually tested?
 - In your SGA block add a link somehow going to `/abc/xyz`. View this in the LMS view, you should see that link unaltered.
 - Change the link to `/static/link.pdf`. View it in the LMS view, it should go to something like `/asset-v1.../link.pdf`. You should also be able to upload a file and use the static link given to you afterwards, and be able to download it via that link.
 - Next, go to advanced settings and update Static Asset Path. Change it to `/123/456`. View the link in LMS, it should now go to `/123/456/link.pdf`. (In the studio view it will remain the `/asset-v1.../link.pdf` link.)