### PR TITLE
Fix space in filename on download

### DIFF
--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -591,6 +591,21 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
             )
             self.assertEqual(response.status_code, 404)
 
+    def test_staff_download_filename_with_spaces(self):
+        """
+        Tests download assignment with spaces in filename.
+        """
+        file_name = 'my assignment 2.txt'
+        block = self.make_one()
+        student = self.make_student(block, 'fred')
+        self.personalize(block, **student)
+        with self.dummy_upload(file_name) as (upload, expected):
+            block.upload_assignment(mock.Mock(params={'assignment': upload}))
+        response = block.staff_download(mock.Mock(params={
+            'student_id': student['item'].student_id}))
+        self.assertEqual(response.body, expected)
+        assert urllib.quote(file_name.encode('utf-8')) in response.content_disposition
+
     @data("my,assignment.txt", "my,1,1,assignment.txt")
     def test_file_download_comma_in_name(self, file_name):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-sga/issues/228

#### What's this PR do?
- it url encode student submission file name, so that firefix do not truncate it. 
- Master branch works fine on chrome but it had issue with firefox

#### How should this be manually tested?
- test students submission download as staff or student from firefox and chrome
- run test ```python manage.py lms --settings=test test edx_sga.tests.integration_tests.StaffGradedAssignmentXblockTests.test_staff_download_filename_with_spaces```

@pdpinch 
