### PR TITLE
quote filename in download

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -862,7 +862,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             return Response(
                 app_iter=file_contents_iter(path),
                 content_type=mime_type,
-                content_disposition="attachment; filename=" + filename.encode('utf-8')
+                content_disposition="attachment; filename=\"" + filename.encode('utf-8') + "\""
             )
         except IOError:
             if require_staff:


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Uploading a file with a comma in the filename causes subsequent download of the file to fail on Chrome only. The fix is to quote the attachment filename.

More information here: http://stackoverflow.com/questions/13578428/duplicate-headers-received-from-server

#### How should this be manually tested?
You can upload a file with comma in its name. And you will be able to download it.

@pdpinch 