### PR TITLE
Fixed weight ignore issue on grade calculation

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -429,6 +429,9 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             state['staff_score'] = score
         state['comment'] = request.params.get('comment', '')
         module.state = json.dumps(state)
+        # to fix score on edx progress page
+        module.grade = score
+        module.max_grade = self.max_score()
         module.save()
         log.info(
             "enter_grade for course:%s module:%s student:%s",
@@ -453,6 +456,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
             self.block_id
         )
         module = self.get_student_module(request.params['module_id'])
+        module.grade = 0
         state = json.loads(module.state)
         state['staff_score'] = None
         state['comment'] = ''
@@ -831,6 +835,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         return {
             'assignments': list(get_student_data()),
             'max_score': self.max_score(),
+            'weight': self.weight,
             'display_name': force_text(self.display_name)
         }
 

--- a/edx_sga/templates/staff_graded_assignment/show.html
+++ b/edx_sga/templates/staff_graded_assignment/show.html
@@ -29,7 +29,11 @@
         </p>
         <p>
           <% if (graded) { %>
-            {% blocktrans %}Your score is <%= graded.score %> / <%= max_score %>{% endblocktrans %}<br/>
+            <% if (weight > 0) { %>
+              {% blocktrans %}Your score is <%= (graded.score / max_score) * weight %> / <%= weight %>{% endblocktrans %}<br/>
+            <% } else { %>
+              {% blocktrans %}Your score is <%= graded.score %> / <%= max_score %>{% endblocktrans %}<br/>
+            <% } %>
             <% if (graded.comment) { %>
               <b>{% trans "Instructor comment" %}</b> <%= graded.comment %><br/>
             <% } %>
@@ -100,8 +104,11 @@
           </td>
           <td>
             <% if (assignment.score !== null) { %>
-              <%= assignment.score %> /
-              <%= max_score %>
+              <% if (weight > 0) { %>
+                <%= (assignment.score / max_score) * weight %> / <%= weight %>
+              <% } else { %>
+                <%= assignment.score %> / <%= max_score %>
+              <% } %>
               <% if (! assignment.approved) { %>
                 ({% trans "Awaiting instructor approval" %})
               <% } %>


### PR DESCRIPTION
#### Background:
- Add Grade to assignment. 
- **Expected behaviour:** Grader will offer a grade between 0 and 100, and should be multiplied by weight to get % of full problem.
- **Actual behaviour:** Grade is a grade between 0 and 100. Problem weight seems to be ignored.

#### What are the relevant tickets?
fixes https://github.com/mitodl/edx-sga/issues/95

#### What's this PR do?
In this PR i am using weight to calculate grade percentage. Applied this logic on two points. Images are attached to demonstrate.

#### How should this be manually tested?
- set weight from studio and observe grade

@pdpinch 
#### Screenshots (if appropriate)
![screen shot 2015-06-04 at 6 18 57 pm](https://cloud.githubusercontent.com/assets/10431250/7984934/399100c6-0ae6-11e5-9a73-313010a96563.png)

![screen shot 2015-06-04 at 6 18 54 pm](https://cloud.githubusercontent.com/assets/10431250/7984959/741e036a-0ae6-11e5-8349-7cfdf1442522.png)

![screen shot 2015-06-04 at 6 18 41 pm](https://cloud.githubusercontent.com/assets/10431250/7984975/a654b7d4-0ae6-11e5-9b24-09d5cdd07dd3.png)
