### PR TITLE
Use edX unit testing requirements

### DIFF
--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -6,27 +6,7 @@ source /edx/app/edxapp/venvs/edxapp/bin/activate
 cd /edx/app/edxapp/edx-platform
 mkdir -p reports
 
-# these pip install commands are adapted from edx-platform/circle.yml
-pip install --exists-action w -r requirements/edx/paver.txt
-
-# Mirror what paver install_prereqs does.
-# After a successful build, CircleCI will
-# cache the virtualenv at that state, so that
-# the next build will not need to install them
-# from scratch again.
-pip install --exists-action w -r requirements/edx/pre.txt
-pip install --exists-action w -r requirements/edx/github.txt
-pip install --exists-action w -r requirements/edx/local.txt
-
-# HACK: within base.txt stevedore had a
-# dependency on a version range of pbr.
-# Install a version which falls within that range.
-pip install  --exists-action w pbr==0.9.0
-pip install --exists-action w -r requirements/edx/django.txt
-pip install --exists-action w -r requirements/edx/base.txt
-pip install --exists-action w -r requirements/edx/paver.txt
-pip install --exists-action w -r requirements/edx/testing.txt
-if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
+pip install -r ./requirements/edx/testing.in
 
 cd /edx-sga
 pip uninstall edx-sga -y


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
I made this change on https://github.com/mitodl/rapid-response-xblock/pull/53 to fix a travis error which doesn't appear to be happening here. However this speeds up dependency installation and it would move away from the package installation steps copied from `circle.yml`.

#### How should this be manually tested?
Tests should pass
