### PR TITLE
Fix integration tests under Django 1.11

### DIFF
--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -143,7 +143,7 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         score = state.pop('score', None)
 
         with transaction.atomic():
-            user = User(username=name)
+            user = User(username=name, email='{}@example.com'.format(name))
             user.save()
             profile = UserProfile(user=user, name=name)
             profile.save()

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -6,27 +6,7 @@ source /edx/app/edxapp/venvs/edxapp/bin/activate
 cd /edx/app/edxapp/edx-platform
 mkdir -p reports
 
-# these pip install commands are adapted from edx-platform/circle.yml
-pip install --exists-action w -r requirements/edx/paver.txt
-
-# Mirror what paver install_prereqs does.
-# After a successful build, CircleCI will
-# cache the virtualenv at that state, so that
-# the next build will not need to install them
-# from scratch again.
-pip install --exists-action w -r requirements/edx/pre.txt
-pip install --exists-action w -r requirements/edx/github.txt
-pip install --exists-action w -r requirements/edx/local.txt
-
-# HACK: within base.txt stevedore had a
-# dependency on a version range of pbr.
-# Install a version which falls within that range.
-pip install  --exists-action w pbr==0.9.0
-pip install --exists-action w -r requirements/edx/django.txt
-pip install --exists-action w -r requirements/edx/base.txt
-pip install --exists-action w -r requirements/edx/paver.txt
-pip install --exists-action w -r requirements/edx/testing.txt
-if [ -e requirements/edx/post.txt ]; then pip install --exists-action w -r requirements/edx/post.txt ; fi
+pip install -r requirements/edx/testing.txt
 
 cd /edx-sga
 pip uninstall edx-sga -y


### PR DESCRIPTION
#### What are the relevant tickets?
[PLAT-1700](https://openedx.atlassian.net/browse/PLAT-1700) - Run edx-sga integration tests after edx-platform Django 1.10 upgrade

#### What's this PR do?
Fix integration tests under recent edx-platform versions with Django 1.11.  There is now a unique constraint on auth_user.email, so multiple students created in the same test case need to have distinct email addresses to avoid a constraint violation exception like this:

```
======================================================================
ERROR: test_get_staff_grading_data (edx_sga.tests.integration_tests.StaffGradedAssignmentXblockTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/tests/integration_tests.py", line 616, in test_get_staff_grading_data
    filename="bar.txt")
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/edx_sga/tests/integration_tests.py", line 143, in make_student
    user.save()
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/contrib/auth/base_user.py", line 80, in save
    super(AbstractBaseUser, self).save(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 808, in save
    force_update=force_update, update_fields=update_fields)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 838, in save_base
    updated = self._save_table(raw, cls, force_insert, force_update, using, update_fields)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 924, in _save_table
    result = self._do_insert(cls._base_manager, using, fields, update_pk, raw)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/base.py", line 963, in _do_insert
    using=using, raw=raw)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/query.py", line 1076, in _insert
    return query.get_compiler(using=using).execute_sql(return_id)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/models/sql/compiler.py", line 1112, in execute_sql
    cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/utils.py", line 94, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/local/lib/python2.7/site-packages/django/db/backends/sqlite3/base.py", line 328, in execute
    return Database.Cursor.execute(self, query, params)
IntegrityError: UNIQUE constraint failed: auth_user.email
```

I also included and completed the fix from #246 to get the integration tests passing in Travis again.

#### How should this be manually tested?
1. python setup.py sdist
2. Install Docker Devstack, with the master branch of each repo checked out
3. Copy dist/edx-sga-0.8.2.tar.gz and the test_data directory to the root of edx-platform (which is also mounted inside the lms container)
4. make lms-shell
5. pip uninstall edx-sga
6. pip install edx-sga-0.8.2.tar.gz
7. mv test_data ../venvs/edxapp/lib/python2.7/site-packages/
8. python manage.py lms --settings=test test edx_sga.tests.integration_tests