### PR TITLE
Correct the courseware imports

### DIFF
--- a/edx_sga/management/commands/sga_migrate_submissions.py
+++ b/edx_sga/management/commands/sga_migrate_submissions.py
@@ -6,8 +6,8 @@ old SGA implementation before v0.4.0 to newer version that uses the
 import json
 
 from django.core.management.base import BaseCommand, CommandError  # lint-amnesty, pylint: disable=import-error
-from courseware.courses import get_course_by_id  # lint-amnesty, pylint: disable=import-error
-from courseware.models import StudentModule  # lint-amnesty, pylint: disable=import-error
+from lms.djangoapps.courseware.courses import get_course_by_id  # lint-amnesty, pylint: disable=import-error
+from lms.djangoapps.courseware.models import StudentModule  # lint-amnesty, pylint: disable=import-error
 from opaque_keys.edx.keys import CourseKey  # lint-amnesty, pylint: disable=import-error
 from student.models import anonymous_id_for_user  # lint-amnesty, pylint: disable=import-error
 from submissions import api as submissions_api  # lint-amnesty, pylint: disable=import-error

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -13,7 +13,7 @@ from zipfile import ZipFile
 import pkg_resources
 import pytz
 
-from courseware.models import StudentModule  # lint-amnesty, pylint: disable=import-error
+from lms.djangoapps.courseware.models import StudentModule  # lint-amnesty, pylint: disable=import-error
 from django.conf import settings  # lint-amnesty, pylint: disable=import-error
 from django.core.exceptions import PermissionDenied  # lint-amnesty, pylint: disable=import-error
 from django.core.files import File  # lint-amnesty, pylint: disable=import-error

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -16,9 +16,9 @@ from opaque_keys.edx.locator import CourseLocator
 from opaque_keys.edx.locations import Location  # lint-amnesty, pylint: disable=import-error
 import pytz
 
-from courseware import module_render as render  # lint-amnesty, pylint: disable=import-error
-from courseware.models import StudentModule  # lint-amnesty, pylint: disable=import-error
-from courseware.tests.factories import StaffFactory  # lint-amnesty, pylint: disable=import-error
+from lms.djangoapps.courseware import module_render as render  # lint-amnesty, pylint: disable=import-error
+from lms.djangoapps.courseware.models import StudentModule  # lint-amnesty, pylint: disable=import-error
+from lms.djangoapps.courseware.tests.factories import StaffFactory  # lint-amnesty, pylint: disable=import-error
 from django.contrib.auth.models import User  # lint-amnesty, pylint: disable=import-error
 from django.core.exceptions import PermissionDenied  # lint-amnesty, pylint: disable=import-error
 from django.db import transaction  # lint-amnesty, pylint: disable=import-error


### PR DESCRIPTION
#### What are the relevant tickets?
(None)

#### What's this PR do?
edx-platform has long warned that "courseware" should be imported as "lms.djangoapps.courseware".  This PR makes that correction.

#### How should this be manually tested?
Unsure.