### PR TITLE
Updated deprecated web fragment class import

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -39,11 +39,11 @@ from student.models import user_by_anonymous_id
 from submissions import api as submissions_api
 from submissions.models import StudentItem as SubmissionsStudent
 from submissions.models import Submission
+from web_fragments.fragment import Fragment
 from webob.response import Response
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from xblock.fields import DateTime, Float, Integer, Scope, String
-from xblock.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.util.duedate import get_extended_due_date


### PR DESCRIPTION
#### What are the relevant tickets?
No ticket

#### What's this PR do?
Changes the `Fragment` import from the deprecated `xblock` library wrapper around the class to the `web_fragments` class

#### How should this be manually tested?
TBD

#### Any background context you want to provide?
https://openedx.atlassian.net/browse/DEPR-59