### PR TITLE
Updated fragment import to remove depreciation warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: python
 python: "2.7"
 matrix:
   include:
+    - before_install:
+        # Pinned to older version because of test fails.
+        - pip install pip==9.0.3 --upgrade
     - install:
       - git clone https://github.com/edx/devstack.git
       # Travis's version of docker-compose doesn't understand :cached, and it's not required anyway, so this removes it

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 python: "2.7"
 matrix:
   include:
-    - before_install:
-        # Pinned to older version because of test fails.
-        - pip install pip==9.0.3 --upgrade
     - install:
       - git clone https://github.com/edx/devstack.git
       # Travis's version of docker-compose doesn't understand :cached, and it's not required anyway, so this removes it

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -43,7 +43,7 @@ from webob.response import Response
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from xblock.fields import DateTime, Float, Integer, Scope, String
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.util.duedate import get_extended_due_date


### PR DESCRIPTION
[PROD-1388](https://openedx.atlassian.net/browse/PROD-1388)

This PR is created because of deprecation warnings for `xblock.fragment` chocking logs in Splunk and other logging services.

This can only be tested if some method like `student_view` is called and there is no warning log is present related to `xblock.fragment` 


