### PR TITLE
Replaced deprecated xblock fragment with web_fragment

### DIFF
--- a/edx_sga/__init__.py
+++ b/edx_sga/__init__.py
@@ -3,4 +3,3 @@ Module for StaffGradedAssignmentXBlock.
 """
 
 __version__ = '0.11.1'
-

--- a/edx_sga/management/__init__.py
+++ b/edx_sga/management/__init__.py
@@ -1,1 +1,0 @@
-# pylint: disable=missing-docstring

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -43,7 +43,7 @@ from webob.response import Response
 from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from xblock.fields import DateTime, Float, Integer, Scope, String
-from xblock.fragment import Fragment
+from web_fragments.fragment import Fragment
 from xblockutils.studio_editable import StudioEditableXBlockMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.util.duedate import get_extended_due_date
@@ -165,7 +165,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         return file_obj.tell() > cls.student_upload_max_size()
 
     @classmethod
-    def parse_xml(cls, node, runtime, keys, id_generator):
+    def parse_xml(cls, node, runtime, keys):  # pylint: disable=arguments-differ
         """
         Override default serialization to handle <solution /> elements
         """
@@ -239,7 +239,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
 
     @XBlock.handler
     def upload_assignment(self, request, suffix=''):
-        # pylint: disable=unused-argument, protected-access
+        # pylint: disable=unused-argument
         """
         Save a students submission file.
         """
@@ -796,7 +796,6 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         grading screen.
         """
         def get_student_data():
-            # pylint: disable=no-member
             """
             Returns a dict of student assignment information along with
             annotated file name, student id and module id, this

--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -10,7 +10,7 @@ import zipfile
 from django.core.files.storage import default_storage
 from edx_sga.constants import ITEM_TYPE
 from edx_sga.utils import get_file_storage_path
-from lms import CELERY_APP  # pylint: disable=no-name-in-module
+from lms import CELERY_APP
 from opaque_keys.edx.locator import BlockUsageLocator
 from student.models import user_by_anonymous_id
 from submissions import api as submissions_api

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -224,7 +224,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
     @mock.patch('edx_sga.sga.render_template')
     @mock.patch('edx_sga.sga.Fragment')
     def test_student_view(self, fragment, render_template):
-        # pylint: disable=unused-argument
         """
         Test student view renders correctly.
         """
@@ -251,6 +250,7 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         self.assertEqual(student_state['upload_allowed'], True)
         self.assertEqual(student_state['max_score'], 100)
         self.assertEqual(student_state['graded'], None)
+        # pylint: disable=no-member
         fragment.add_css.assert_called_once_with(
             DummyResource("static/css/edx_sga.css"))
         fragment.initialize_js.assert_called_once_with(
@@ -292,7 +292,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
     @mock.patch('edx_sga.sga.render_template')
     @mock.patch('edx_sga.sga.Fragment')
     def test_student_view_with_score(self, fragment, render_template):
-        # pylint: disable=unused-argument
         """
         Tests scores are displayed correctly on student view.
         """
@@ -320,13 +319,13 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         self.assertEqual(student_state['max_score'], 100)
         self.assertEqual(student_state['graded'],
                          {u'comment': '', u'score': 10})
+        # pylint: disable=no-member
         fragment.add_css.assert_called_once_with(
             DummyResource("static/css/edx_sga.css"))
         fragment.initialize_js.assert_called_once_with(
             "StaffGradedAssignmentXBlock")
 
     def test_studio_view(self):
-        # pylint: disable=unused-argument
         """
         Test studio view is using the StudioEditableXBlockMixin function
         """
@@ -407,9 +406,9 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
 
         with mock.patch(
             "edx_sga.sga.StaffGradedAssignmentXBlock.file_storage_path",
-            return_value=block.file_storage_path(  # lint-amnesty, pylint: disable=protected-access
+            return_value=block.file_storage_path(  # lint-amnesty
                 "", "test_notfound.txt"
-            )  # lint-amnesty, pylint: disable=protected-access
+            )  # lint-amnesty
         ):
             response = block.download_assignment(None)
             self.assertEqual(response.status_code, 404)
@@ -430,7 +429,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         self.assertTrue(recent_submission_data['answer']['finalized'])
 
     def test_staff_upload_download_annotated(self):
-        # pylint: disable=no-member
         """
         Tests upload and download of annotated staff files.
         """
@@ -446,9 +444,9 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
 
         with mock.patch(
             "edx_sga.sga.StaffGradedAssignmentXBlock.file_storage_path",
-            return_value=block.file_storage_path(  # lint-amnesty, pylint: disable=protected-access
+            return_value=block.file_storage_path(  # lint-amnesty
                 "", "test_notfound.txt"
-            )  # lint-amnesty, pylint: disable=protected-access
+            )  # lint-amnesty
         ):
             response = block.staff_download_annotated(
                 mock.Mock(
@@ -460,7 +458,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
             self.assertEqual(response.status_code, 404)
 
     def test_staff_upload_annotated_state(self):
-        # pylint: disable=no-member
         """
         Test state recorded in the module state when staff_upload_annotated is called
         """
@@ -486,7 +483,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         assert state['annotated_sha1'] == get_sha1(expected)
 
     def test_download_annotated(self):
-        # pylint: disable=no-member
         """
         Test download annotated assignment for non staff.
         """
@@ -511,10 +507,10 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
 
         with mock.patch(
             "edx_sga.sga.StaffGradedAssignmentXBlock.file_storage_path",
-            return_value=block.file_storage_path(  # lint-amnesty, pylint: disable=protected-access
+            return_value=block.file_storage_path(  # lint-amnesty
                 "",
                 "test_notfound.txt"
-            )  # lint-amnesty, pylint: disable=protected-access
+            )  # lint-amnesty
         ):
             response = block.download_annotated(None)
             self.assertEqual(response.status_code, 404)
@@ -546,10 +542,10 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         for student, __ in students:
             with mock.patch(
                 "edx_sga.sga.StaffGradedAssignmentXBlock.file_storage_path",
-                return_value=block.file_storage_path(  # lint-amnesty, pylint: disable=protected-access
+                return_value=block.file_storage_path(  # lint-amnesty
                     "",
                     "test_notfound.txt"
-                )  # lint-amnesty, pylint: disable=protected-access
+                )  # lint-amnesty
             ):
                 response = block.staff_download(
                     mock.Mock(
@@ -577,10 +573,10 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
 
         with mock.patch(
             "edx_sga.sga.StaffGradedAssignmentXBlock.file_storage_path",
-            return_value=block.file_storage_path(  # lint-amnesty, pylint: disable=protected-access
+            return_value=block.file_storage_path(  # lint-amnesty
                 "",
                 "test_notfound.txt"
-            )  # lint-amnesty, pylint: disable=protected-access
+            )  # lint-amnesty
         ):
             response = block.download_annotated(None)
             self.assertEqual(response.status_code, 404)
@@ -600,10 +596,10 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
 
         with mock.patch(
             "edx_sga.sga.StaffGradedAssignmentXBlock.file_storage_path",
-            return_value=block.file_storage_path(  # lint-amnesty, pylint: disable=protected-access
+            return_value=block.file_storage_path(  # lint-amnesty
                 "",
                 "test_notfound.txt"
-            )  # lint-amnesty, pylint: disable=protected-access
+            )  # lint-amnesty
         ):
             response = block.staff_download(
                 mock.Mock(
@@ -654,7 +650,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
             block.get_staff_grading_data(None)
 
     def test_get_staff_grading_data(self):
-        # pylint: disable=no-member
         """
         Test fetch grading data for staff members.
         """
@@ -725,7 +720,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         self.assertIn(block.location, module_creation_log_message)
 
     def test_enter_grade_instructor(self):
-        # pylint: disable=no-member
         """
         Test enter grade by instructors.
         """
@@ -743,7 +737,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         self.assertEqual(block.get_score(fred['item'].student_id), 9)
 
     def test_enter_grade_staff(self):
-        # pylint: disable=no-member
         """
         Test grade enter by staff.
         """
@@ -761,7 +754,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
 
     @data(None, "", '9.24', "second")
     def test_enter_grade_fail(self, grade):
-        # pylint: disable=no-member
         """
         Tests grade enter fail.
         """
@@ -785,7 +777,6 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         )
 
     def test_remove_grade(self):
-        # pylint: disable=no-member
         """
         Test remove grade.
         """

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -32,7 +32,7 @@ try:
     import six.moves.builtins as builtins  # pylint: disable=ungrouped-imports
 except ImportError:
     # Python 3
-    import builtins  # pylint: disable=ungrouped-imports
+    import builtins
 
 
 SHA1 = 'da39a3ee5e6b4b0d3255bfef95601890afd80709'
@@ -206,7 +206,6 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
     @mock.patch('edx_sga.sga.render_template')
     @mock.patch('edx_sga.sga.Fragment')
     def test_student_view(self, fragment, render_template):
-        # pylint: disable=unused-argument
         """
         Test student view renders correctly.
         """
@@ -238,6 +237,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
             assert student_state['upload_allowed'] is True
             assert student_state['max_score'] == 100
             assert student_state['graded'] is None
+            # pylint: disable=no-member
             fragment.add_css.assert_called_once_with(
                 DummyResource("static/css/edx_sga.css"))
             fragment.initialize_js.assert_called_once_with(
@@ -249,7 +249,6 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
     @mock.patch('edx_sga.sga.render_template')
     @mock.patch('edx_sga.sga.Fragment')
     def test_student_view_with_score(self, fragment, render_template, get_score, upload_allowed):
-        # pylint: disable=unused-argument
         """
         Tests scores are displayed correctly on student view.
         """
@@ -292,7 +291,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
                 assert student_state['uploaded'] == {'filename': 'foo.txt'}
                 assert student_state['graded'] == {'comment': 'ok', 'score': 10}
                 assert student_state['max_score'] == 100
-
+                # pylint: disable=no-member
                 fragment.add_css.assert_called_once_with(
                     DummyResource("static/css/edx_sga.css"))
                 fragment.initialize_js.assert_called_once_with(
@@ -459,7 +458,6 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
     @mock.patch('edx_sga.sga.StaffGradedAssignmentXBlock.is_course_staff')
     @mock.patch('edx_sga.sga.get_sha1')
     def test_staff_upload_download_annotated(self, get_sha1, is_course_staff, get_student_module):
-        # pylint: disable=no-member
         """
         Tests upload and download of annotated staff files.
         """
@@ -496,7 +494,6 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
     @mock.patch('edx_sga.sga.StaffGradedAssignmentXBlock.is_course_staff')
     @mock.patch('edx_sga.sga.get_sha1')
     def test_download_annotated(self, get_sha1, is_course_staff, get_student_module):
-        # pylint: disable=no-member
         """
         Test download annotated assignment for non staff.
         """

--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
     install_requires=[
         'XBlock',
         'xblock-utils',
+        'web_fragments',
     ],
     entry_points={
         'xblock.v1': [

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27, 35}-django{111}
+envlist = py{27,35}-django{111}
 
 [testenv]
 passenv =


### PR DESCRIPTION
#### What are the relevant tickets?
https://openedx.atlassian.net/browse/BOM-1862

#### What's this PR do?
remove deprecated usage of `xblock.fragment`