### PR TITLE
asadiqbal08/Allow a grade of zero

### DIFF
--- a/edx_sga/static/js/src/edx_sga.js
+++ b/edx_sga/static/js/src/edx_sga.js
@@ -242,7 +242,7 @@ function StaffGradedAssignmentXBlock(runtime, element) {
                 var max_score = row.parents('#grade-info').data('max_score');
                 var score = Number(form.find('#grade-input').val());
                 event.preventDefault();
-                if (!score) {
+                if (isNaN(score)) {
                     gradeFormError('<br/>'+gettext('Grade must be a number.'));
                 } else if (score !== parseInt(score)) {
                     gradeFormError('<br/>'+gettext('Grade must be an integer.'));


### PR DESCRIPTION
#### What are the relevant tickets?
fixes: #278 

#### What's this PR do?
Instructor can enter Grade 0

#### How should this be manually tested?
Integrate the edx-sga xBlock in openEdx (using studio).
In LMS, upload the assignment against the SGA xBlock.
In Studio, Instructor can add 0 when submitting grade.



#### Screenshots (if appropriate)

<img width="1208" alt="Screen Shot 2020-09-30 at 2 34 54 PM" src="https://user-images.githubusercontent.com/7334669/94669034-2e95a180-032a-11eb-865d-54f9ca54f3db.png">

<img width="1194" alt="Screen Shot 2020-09-30 at 2 35 02 PM" src="https://user-images.githubusercontent.com/7334669/94669019-2a698400-032a-11eb-895d-9c1190d0710e.png">
