### PR TITLE
asadiqbal08/Fixes the release failure over OpenEdx

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -165,7 +165,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         return file_obj.tell() > cls.student_upload_max_size()
 
     @classmethod
-    def parse_xml(cls, node, runtime, keys):  # pylint: disable=arguments-differ
+    def parse_xml(cls, node, runtime, keys, id_generator):  # pylint: disable=arguments-differ
         """
         Override default serialization to handle <solution /> elements
         """


### PR DESCRIPTION
#### What are the relevant tickets?
fixes: #281 

#### What's this PR do?
Update the method definition of `parse_xml` in SGA xblock that was removed in [PR#270](https://github.com/mitodl/edx-sga/pull/270/files#diff-52fbfd5003bb036038e11d03721c4253R168)

#### How should this be manually tested?
- Checkout that PR of edx-sga, 
- Installed that changes in open EdX. (Do not forget to comment out / skip the current pinned version of edx-sga in openEdx before installation)
- Run the test, that was failing the build, it was : 
`lms/djangoapps/grades/tests/integration/test_problems.py`
Test should be passed this time.


#### SOLUTION CONTEXT
I have to update the definition of `parse_xml` in SGA xBlock because xBlock runtime module has a method declaration `add_node_as_child` that is called by XBlock.parse_xml to treat a child node as a child block.
[Reference Code](https://github.com/edx/edx-platform/blob/master/openedx/core/djangoapps/xblock/runtime/runtime.py#L202-L207)

