### PR TITLE
Fix DeprecatedEdxPlatformImportWarning

### DIFF
--- a/edx_sga/management/commands/sga_migrate_submissions.py
+++ b/edx_sga/management/commands/sga_migrate_submissions.py
@@ -11,7 +11,7 @@ from django.core.management.base import BaseCommand, CommandError
 from lms.djangoapps.courseware.courses import get_course_by_id
 from lms.djangoapps.courseware.models import StudentModule
 from opaque_keys.edx.keys import CourseKey
-from student.models import anonymous_id_for_user
+from common.djangoapps.student.models import anonymous_id_for_user
 from submissions import api as submissions_api
 from xmodule.modulestore.django import modulestore
 

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -35,7 +35,7 @@ from edx_sga.utils import (file_contents_iter, get_file_modified_time_utc,
                            is_finalized_submission, utcnow)
 from lms.djangoapps.courseware.models import StudentModule
 from safe_lxml import etree
-from student.models import user_by_anonymous_id
+from common.djangoapps.student.models import user_by_anonymous_id
 from submissions import api as submissions_api
 from submissions.models import StudentItem as SubmissionsStudent
 from submissions.models import Submission
@@ -165,7 +165,7 @@ class StaffGradedAssignmentXBlock(StudioEditableXBlockMixin, ShowAnswerXBlockMix
         return file_obj.tell() > cls.student_upload_max_size()
 
     @classmethod
-    def parse_xml(cls, node, runtime, keys, id_generator):  # pylint: disable=arguments-differ
+    def parse_xml(cls, node, runtime, keys, id_generator):
         """
         Override default serialization to handle <solution /> elements
         """

--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -12,7 +12,7 @@ from edx_sga.constants import ITEM_TYPE
 from edx_sga.utils import get_file_storage_path
 from lms import CELERY_APP
 from opaque_keys.edx.locator import BlockUsageLocator
-from student.models import user_by_anonymous_id
+from common.djangoapps.student.models import user_by_anonymous_id
 from submissions import api as submissions_api
 
 log = logging.getLogger(__name__)

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -31,8 +31,8 @@ from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tests.factories import StaffFactory
 from opaque_keys.edx.locations import Location
 from opaque_keys.edx.locator import CourseLocator
-from student.models import UserProfile, anonymous_id_for_user
-from student.tests.factories import AdminFactory
+from common.djangoapps.student.models import UserProfile, anonymous_id_for_user
+from common.djangoapps.student.tests.factories import AdminFactory
 from submissions import api as submissions_api
 from submissions.models import StudentItem
 from xblock.field_data import DictFieldData

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -123,7 +123,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
             try:
                 return real_import(name, *args, **kwargs)
             except ImportError:
-                for module in ('courseware', 'lms', 'student', 'xmodule'):
+                for module in ('common', 'courseware', 'lms', 'xmodule'):
                     if name.startswith("{}.".format(module)) or name == module:
                         return mock.Mock()
                 if name == 'safe_lxml':

--- a/pylintrc
+++ b/pylintrc
@@ -26,28 +26,17 @@
 # 1. Edit the pylintrc file in the edx-lint repo at
 #    https://github.com/edx/edx-lint/blob/master/edx_lint/files/pylintrc
 #
-# 2. install the updated version of edx-lint (in edx-lint):
+# 2. Make a new version of edx_lint, which involves the usual steps of
+#    incrementing the version number, submitting and reviewing a pull
+#    request, and updating the edx-lint version reference in this repo.
 #
-#       $ pip install .
+# 3. Install the newer version of edx-lint.
 #
-# 3. Run (in edx-lint):
+# 4. Run:
 #
-#       # uses pylintrc_tweaks from edx-lint for linting in edx-lint
-#       # NOTE: Use Python 3.x, which no longer includes comments in the output file
 #       $ edx_lint write pylintrc
 #
-# 4. Make a new version of edx_lint, submit and review a pull request with the
-#    pylintrc update, and after merging, update the edx-lint version by
-#    creating a new tag in the repo (uses pbr).
-#
-# 5. In your local repo, install the newer version of edx-lint.
-#
-# 6. Run:
-#
-#       # uses local pylintrc_tweaks
-#       $ edx_lint write pylintrc
-#
-# 7. This will modify the local file.  Submit a pull request to get it
+# 5. This will modify the local file.  Submit a pull request to get it
 #    checked in so that others will benefit.
 #
 #
@@ -262,6 +251,7 @@ enable =
 	too-many-boolean-expressions,
 	# Consistent import order makes finding where code is
 	# imported from easier
+	ungrouped-imports,
 	wrong-import-order,
 	wrong-import-position,
 	wildcard-import,
@@ -349,7 +339,6 @@ disable =
 	too-many-locals,
 	too-many-public-methods,
 	too-many-return-statements,
-	ungrouped-imports,
 	unichr-builtin,
 	unicode-builtin,
 	unpacking-in-except,
@@ -357,6 +346,7 @@ disable =
 	xrange-builtin,
 	zip-builtin-not-iterating,
 	import-error,
+	no-name-in-module
 
 [REPORTS]
 output-format = text
@@ -383,7 +373,7 @@ docstring-min-length = 5
 
 [FORMAT]
 max-line-length = 120
-ignore-long-lines = ^\s*(# )?((<?https?://\S+>?)|(\.\. \w+: .*))$
+ignore-long-lines = ^\s*(# )?<?https?://\S+>?$
 single-line-if-stmt = no
 no-space-check = trailing-comma,dict-separator
 max-module-lines = 1000
@@ -456,4 +446,4 @@ int-import-graph =
 [EXCEPTIONS]
 overgeneral-exceptions = Exception
 
-# 5e224b2fc4e2cff4774a538db1939b726b0dba51
+# 1bdafb6ee03147da94f0de97d74646621e48225f

--- a/pylintrc_tweaks
+++ b/pylintrc_tweaks
@@ -6,3 +6,4 @@
 # disable import-error due to us pylint disabling it everywhere in code
 disable+ =
     import-error,
+    no-name-in-module


### PR DESCRIPTION
#### What are the relevant tickets?
(Required)

#### What's this PR do?
This PR would remove this warning that occurs in Studio every time that the service is run.
```python
2020-11-20 18:04:24,829 WARNING 78 [py.warnings] [user None] [ip None] warnings.py:109 - /edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_sga/tasks.py:15: DeprecatedEdxPlatformImportWarning: Importing student.models instead of common.djangoapps.student.models is deprecated
  from student.models import user_by_anonymous_id
```

You can test this by running the devstack this:

make studio-shell
/edx/bin/edxapp-shell-cms

This should throw the DeprecatedEdxPlatformImportWarning warning. Then, install this version of edx-sga and the warning should dissapear.

Related PRs: https://github.com/edx/edx-platform/pull/25477

#### Any background context you want to provide?
https://discuss.openedx.org/t/squash-a-warning-earn-a-badge/3497/13
