### PR TITLE
Pulling the APP from LMS breaks if we're running in CMS

### DIFF
--- a/edx_sga/tasks.py
+++ b/edx_sga/tasks.py
@@ -10,7 +10,7 @@ import zipfile
 from django.core.files.storage import default_storage
 from edx_sga.constants import ITEM_TYPE
 from edx_sga.utils import get_file_storage_path
-from lms import CELERY_APP
+from celery import shared_task
 from opaque_keys.edx.locator import BlockUsageLocator
 from common.djangoapps.student.models import user_by_anonymous_id
 from submissions import api as submissions_api
@@ -84,7 +84,7 @@ def _compress_student_submissions(zip_file_path, block_id, course_id, locator):
         default_storage.save(zip_file_path, tmp)
 
 
-@CELERY_APP.task
+@shared_task
 def zip_student_submissions(course_id, block_id, locator_unicode, username):
     """
     Task to download all submissions as zip file


### PR DESCRIPTION
Switch to using the `shared_task` mechanism of celery.

If we don't do that, it results in the LMS celery app being instantiated in Studio
when the xblock is loaded in Studio.  This can lead to strange downstream effects
including other tasks not getting registered properly at runtime.

#### What are the relevant tickets?
(Required)

#### What's this PR do?
(Required)

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
