### PR TITLE
fixes utc time assignment to download all submissions

### DIFF
--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -40,11 +40,13 @@ def get_file_modified_time_utc(file_path):
         if settings.DEFAULT_FILE_STORAGE == 'django.core.files.storage.FileSystemStorage'
         else pytz.utc
     )
-    return file_timezone.localize(
-        default_storage.get_modified_time(file_path)
-    ).astimezone(
-        pytz.utc
-    )
+
+    file_time = default_storage.get_modified_time(file_path)
+
+    if file_time.tzinfo is None:
+        return file_timezone.localize(file_time).astimezone(pytz.utc)
+    else:
+        return file_time.astimezone(pytz.utc)
 
 
 def get_sha1(file_descriptor):


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/edx-sga/issues/296

#### What's this PR do?
Download all submission button was not functioning properly due to a timezone assignment issue, this PR fixes that by applying some checks regarding time zone.

#### How should this be manually tested?
You can simply try downloading all assignments through the studio's interface.
