### PR TITLE
fix: update sga item_type to be same as block_type

### DIFF
--- a/edx_sga/constants.py
+++ b/edx_sga/constants.py
@@ -1,7 +1,7 @@
 """Constants"""
 
 BLOCK_SIZE = 2**10 * 8  # 8kb
-ITEM_TYPE = 'sga'
+ITEM_TYPE = 'edx_sga'
 
 
 class ShowAnswer:

--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -98,7 +98,7 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
         Make scope ids
         """
         # Not sure if this is a valid block type, might be sufficient for testing purposes
-        block_type = 'sga'
+        block_type = 'edx_sga'
         def_id = runtime.id_generator.create_definition(block_type)
         return ScopeIds(
             'user', block_type, def_id, self.descriptor.location
@@ -156,7 +156,7 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
                 student_id=anonymous_id,
                 course_id=self.course_id,
                 item_id=block.block_id,
-                item_type='sga')
+                item_type='edx_sga')
             item.save()
 
             if answer:

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -368,7 +368,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
             "student_id": 1,
             "course_id": block.block_course_id,
             "item_id": block.block_id,
-            "item_type": 'sga',
+            "item_type": 'edx_sga',
         }
         upload_allowed.return_value = True
 
@@ -421,7 +421,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
             "student_id": 1,
             "course_id": block.block_course_id,
             "item_id": block.block_id,
-            "item_type": 'sga',
+            "item_type": 'edx_sga',
         }
         upload_allowed.return_value = True
         existing_submitted_at_value = django_now()


### PR DESCRIPTION
#### What are the relevant tickets?
AU-70

#### What's this PR do?
There were confusion for using item_type different from block_type. This pr is to make item_type and block_type the same within `edx-platform`

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
