### PR TITLE
Update license text to match pypi's acceptable list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     name="edx-sga",
     version=edx_sga.__version__,
     description="edx-sga Staff Graded Assignment XBlock",
-    license="Affero GNU General Public License v3 (GPLv3)",
+    license="GNU Affero General Public License v3 or later (AGPLv3+)",
     url="https://github.com/mitodl/edx-sga",
     author="MITx",
     zip_safe=False,


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Updates the license text. The pypi publish was failing because there is now a check that the license text matches [this list](https://pypi.org/classifiers/). This should tweak the text to match an existing value.

#### How should this be manually tested?
N/A, we need to publish to check this