### PR TITLE
fix!: use full import path to safe_lxml

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -25,7 +25,7 @@ from django.utils.encoding import force_text
 from django.utils.timezone import now as django_now
 from django.utils.translation import gettext as _
 from lms.djangoapps.courseware.models import StudentModule
-from safe_lxml import etree
+from openedx.core.lib.safe_lxml import etree
 from common.djangoapps.student.models import user_by_anonymous_id
 from submissions import api as submissions_api
 from submissions.models import StudentItem as SubmissionsStudent

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -116,7 +116,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
                 for module in ("common", "courseware", "lms", "xmodule"):
                     if name.startswith(f"{module}.") or name == module:
                         return mock.Mock()
-                if name == "safe_lxml":
+                if name == "openedx.core.lib.safe_lxml":
                     return real_import("lxml", *args, **kwargs)
                 raise
 


### PR DESCRIPTION
#### What's this PR do?

Previously, edx-platform's safe_lxml module was imported as:

    import safe_lxml

This still works, but will stop working very soon.

This commit updates edx-sga's usage of safe_lxml to the new, correct import path:

    import openedx.core.lib.safe_lxml

This change is NOT backwards-compatible with Nutmeg or earlier.
Bumps edx-sga version to 0.19.0.

#### What are the relevant tickets? / Any background context you want to provide?

  * Forum post detailing recent edx-platform import changes: https://discuss.openedx.org/t/breaking-apart-edx-platforms-common-lib-folder/7556
  * Jira epic explaining rationale behind changes: https://openedx.atlassian.net/browse/BOM-2579
  * Specific Jira ticket describing what changed in edx-platform: https://openedx.atlassian.net/browse/BOM-2583
  * edx-platform PR to remove compatibility hack, which this edx-sga PR blocks: https://github.com/openedx/edx-platform/pull/30671

#### How should this be manually tested?

This is probably safe without further manual testing, but anyway here's what I did:
* I ran unit tests via `tox` and confirmed they passed. Pylint failed, but it failed on master too.
* I made sure this worked with [the corresponding branch of edx-platform](https://github.com/openedx/edx-platform/pull/30671). From within `tutor dev run lms bash -m path/to/my/edx-platform`:
  * I installed my version of edx-sga:
    * `pip install git+https://github.com/kdmccormick/edx-sga@kdmccormick/fix-safe-lxml-import#egg=edx-sga==0.19.0`
  * I ran these tests, which had been failing because of the old safe_lxml import in edx-sga:
    * `pytest lms/djangoapps/grades/tests/test_scores.py -k possibly_scored`


#### Where should the reviewer start?

Changes should be pretty non-controversial, but let me know if you have concerns.

One thing: If this commit merges as-is, `master` of this repo will be incompatible with `open-release/nutmeg.master` of edx-platform (and earlier). Is that OK? Or does `master` of this repo need to support older versions of edx-platform?

#### Screenshots (if appropriate)

N/A

#### What GIF best describes this PR or how it makes you feel?

I'm just going around breaking stuff:

![gunter-breaking-everything](https://user-images.githubusercontent.com/3628148/177882119-4e6c8a6f-a513-4577-823f-144a9c5c34e1.gif)

(just kidding, hopefully)

