### PR TITLE
test: import block_render instead of module_render [BD-13]

### DIFF
--- a/edx_sga/tests/integration_tests.py
+++ b/edx_sga/tests/integration_tests.py
@@ -19,7 +19,7 @@ from django.contrib.auth.models import User
 from django.core.exceptions import PermissionDenied
 from django.db import transaction
 from django.test.utils import override_settings
-from lms.djangoapps.courseware import module_render as render
+from lms.djangoapps.courseware import block_render as render
 from lms.djangoapps.courseware.models import StudentModule
 from lms.djangoapps.courseware.tests.factories import StaffFactory
 from opaque_keys.edx.locations import Location
@@ -95,7 +95,7 @@ class StaffGradedAssignmentXblockTests(TempfileMixin, ModuleStoreTestCase):
             course=self.course,
             # not sure why this isn't working, if set to true it looks for
             # 'display_name_with_default_escaped' field that doesn't exist in SGA
-            wrap_xmodule_display=False,
+            wrap_xblock_display=False,
             **kwargs,
         )
         return runtime


### PR DESCRIPTION
#### What's this PR do?

See https://github.com/openedx/edx-platform/pull/31475 for the backstory.

This PR is fixing integration tests by changing `module_render` import to `block_render`.

#### How should this be manually tested?

The PR has to pass all CI checks.