### PR TITLE
feat: allow to configure upload file size

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -86,7 +86,14 @@ class StaffGradedAssignmentXBlock(
 
     has_score = True
     icon_class = "problem"
-    STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
+    # validate if STUDENT_FILEUPLOAD_MAX_SIZE variables is defined in config.yml
+    # with custom upload size, if not put the default 4mb allowed
+    custom_file_size = settings.STUDENT_FILEUPLOAD_MAX_SIZE
+    if custom_file_size:
+        STUDENT_FILEUPLOAD_MAX_SIZE = custom_file_size
+    else:
+        STUDENT_FILEUPLOAD_MAX_SIZE = 4 * 1000 * 1000  # 4 MB
+    #########
     editable_fields = ("display_name", "points", "weight", "showanswer", "solution")
 
     display_name = String(


### PR DESCRIPTION
#### What are the relevant tickets?
None, it will be useful for users to be able to customize the upload size of documents.

#### What's this PR do?
This PR is intended to can customize the upload size limit

#### How should this be manually tested?
Add the STUDENT_FILEUPLOAD_MAX_SIZE variable with the custom size in the config.yml

Example:
`STUDENT_FILEUPLOAD_MAX_SIZE = 10 * 1000 * 1000  #10MB`
