### PR TITLE
fix: use block_id in place of name attribute

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -582,7 +582,7 @@ class StaffGradedAssignmentXBlock(
         """
         context = {
             "student_state": json.dumps(self.student_state()),
-            "id": self.location.name.replace(".", "_"),
+            "id": self.location.block_id.replace(".", "_"),
             "max_file_size": self.student_upload_max_size(),
             "support_email": settings.TECH_SUPPORT_EMAIL,
         }


### PR DESCRIPTION
Replace `location.name` (deprecated) with `location.block_id`.

#### What are the relevant tickets?
N/A

#### What's this PR do?
This PR partly [resolves this deprecation warning documented here](https://github.com/openedx/public-engineering/issues/156).

`location.name` is deprecated [as seen here](https://github.com/openedx/opaque-keys/blob/master/opaque_keys/edx/locator.py#L903C14-L903C63) and the use of `location.block_id` is preferred.

#### How should this be manually tested?
Running `tox`

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
