### PR TITLE
chore: remove depreciation warnings for django 4.2.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ the SGA XBlock in devstack.**
 
     ```
     MEDIA_ROOT = "/edx/var/edxapp/uploads"
-    DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    STORAGES = {
+       "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+    }
+}
     ```
     
     You can also configure S3 to be used as the file storage backend. Ask a fellow developer or devops for the

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -34,7 +34,7 @@ from xblock.core import XBlock
 from xblock.exceptions import JsonHandlerError
 from xblock.fields import DateTime, Float, Integer, Scope, String
 from web_fragments.fragment import Fragment
-from xblockutils.studio_editable import StudioEditableXBlockMixin
+from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.util.duedate import get_extended_due_date
 
@@ -582,7 +582,7 @@ class StaffGradedAssignmentXBlock(
         """
         context = {
             "student_state": json.dumps(self.student_state()),
-            "id": self.location.name.replace(".", "_"),
+            "id": self.location.block_id,
             "max_file_size": self.student_upload_max_size(),
             "support_email": settings.TECH_SUPPORT_EMAIL,
         }

--- a/edx_sga/test_settings.py
+++ b/edx_sga/test_settings.py
@@ -6,7 +6,11 @@ Django settings for edx_sga project.
 
 import os
 
-DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    }
+}
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = "k(g$9p*x^a=t_lf$%=b*3$$ipg1g0tm!^pws0@g)u+v@&$657n"
 DEBUG = True
@@ -61,7 +65,7 @@ DATABASES = {
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 USE_I18N = True
-USE_L10N = True
+# USE_L10N = True
 USE_TZ = True
 STATIC_URL = "/static/"
 TECH_SUPPORT_EMAIL = "support@example.com"

--- a/edx_sga/tests/common.py
+++ b/edx_sga/tests/common.py
@@ -34,10 +34,10 @@ class TempfileMixin(unittest.TestCase):
         Creates a temp directory and fixes Django settings
         """
         cls._original_media_root = settings.MEDIA_ROOT
-        cls._original_file_storage = settings.DEFAULT_FILE_STORAGE
+        cls._original_file_storage = settings.STORAGES["default"]["BACKEND"]
         cls.temp_directory = mkdtemp()
         settings.MEDIA_ROOT = cls.temp_directory
-        settings.DEFAULT_FILE_STORAGE = "django.core.files.storage.FileSystemStorage"
+        settings.STORAGES["default"]["BACKEND"]= "django.core.files.storage.FileSystemStorage"
         cls.default_storage = default_storage
 
     @classmethod
@@ -47,7 +47,7 @@ class TempfileMixin(unittest.TestCase):
         """
         shutil.rmtree(cls.temp_directory, ignore_errors=True)
         settings.MEDIA_ROOT = cls._original_media_root
-        settings.DEFAULT_FILE_STORAGE = cls._original_file_storage
+        settings.STORAGES["default"]["BACKEND"] = cls._original_file_storage
         del cls._original_media_root
         del cls._original_file_storage
 

--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -61,7 +61,7 @@ def get_file_modified_time_utc(file_path):
         # time.tzname returns a 2 element tuple:
         #   (local non-DST timezone, e.g.: 'EST', local DST timezone, e.g.: 'EDT')
         pytz.timezone(time.tzname[0])
-        if settings.DEFAULT_FILE_STORAGE
+        if settings.STORAGES["default"]["BACKEND"]
         == "django.core.files.storage.FileSystemStorage"
         else pytz.utc
     )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38}-django{32}
+envlist = py{38}-django{42}
 
 [testenv]
 passenv =
@@ -7,7 +7,7 @@ passenv =
     CI
 
 deps =
-    django32: Django>=3.2,<3.3
+    django42: Django>=4.2,<4.3
     -r test_requirements.txt
 
 commands =


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/edx-sga/issues/352

#### What's this PR do?
This PR updates tox to run django42 and removes all the depreciations warnings related to edx-sga coming from django and edx-platform

#### How should this be manually tested?
Run tox 

Note: Testing is done for django 4.2.x and edx-platform should be ideally at quince.master which is using django version 4.2.8
