### PR TITLE
Allow SGA blocks to be used in Libraries v2 context [FC-0076]

### DIFF
--- a/edx_sga/__init__.py
+++ b/edx_sga/__init__.py
@@ -2,4 +2,4 @@
 Module for StaffGradedAssignmentXBlock.
 """
 
-__version__ = "0.25.0"
+__version__ = "0.25.1"

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -644,8 +644,10 @@ class StaffGradedAssignmentXBlock(
     def block_course_id(self):
         """
         Return the course_id of the block.
+
+        Note: if this block is used in a Content Library, the returned ID will be the library's ID.
         """
-        return str(self.course_id)
+        return str(self.context_key)
 
     def get_student_item_dict(self, student_id=None):
         """

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -700,13 +700,18 @@ class StaffGradedAssignmentXBlock(
         """
         Add context info for the Staff Debug interface.
         """
-        published = self.start
+        published = getattr(self, 'start', None)
         context["is_released"] = published and published < utcnow()
         context["location"] = self.location
         context["category"] = type(self).__name__
-        context["fields"] = [
-            (name, field.read_from(self)) for name, field in self.fields.items()
-        ]
+        context["fields"] = []
+
+        for name, field in self.fields.items():
+            try:
+                context["fields"].append((name, field.read_from(self)))
+            # Library blocks only support the content and settings scopes
+            except NotImplementedError:
+                pass
 
     def get_student_module(self, module_id):
         """


### PR DESCRIPTION
#### What are the relevant tickets?
Part of: https://github.com/openedx/frontend-app-authoring/issues/1514
Private-ref: [FAL-4032](https://tasks.opencraft.com/browse/FAL-4032)

#### What's this PR do?

Fixes errors thrown when previewing/editing SGA blocks in a Libraries v2 context.

#### How should this be manually tested?

To verify the issues fixed here:
1. Ensure that `edx_sga` is in the list of `LIBRARY_SUPPORTED_BLOCKS` configured for your Authoring MFE.
1. Import the Open edX Demo course into your tutor dev stack (`tutor dev do importdemocourse`)
2. Navigate to the Open edX Demo course and locate the [Staff Graded Assignment (sga) block](http://apps.local.openedx.io:2001/authoring/course/course-v1:OpenCraft+DemoX+1/container/block-v1:OpenCraft+DemoX+1+type@vertical+block@8c8427e057e84af39a4fb9239eb37c8a?show=block-v1%3AOpenCraft%2BDemoX%2B1%2Btype%40edx_sga%2Bblock%40f1a333afcf1b4e80a4c83074948174af).
3. Copy the SGA block to your staging clipboard.
4. Go back to the Authoring MFE home page, and create a new content library.
5. Paste the copied SGA component into your library.
7. Click on the SGA card to display its Preview in the sidebar, and/or click Expand to view it in a modal.
8. Click "Edit Component" to edit the SGA block.

To test this fix:
1. Install this branch in your CMS, e.g. `tutor dev exec cms pip install git+https://github.com/mitodl/edx-sga.git@refs/pull/363/head`
2. Repeat the verification steps above while watching the CMS logs.
3. Ensure the SGA Preview shows the same content that was displayed for the SGA block in the course.
4. Ensure that you can edit and save changes to the library SGA block from within the library context.

#### Screenshots

![image](https://github.com/user-attachments/assets/61d074f2-d100-45b6-87a6-7958f177d20d)
