### PR TITLE
feat!: Adding django52 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         os: [ubuntu-24.04]
         python-version: ['3.12']
         edx_branch: ['master', 'open-release/redwood.master', 'open-release/sumac.master']
-        toxenv: [py312-django32, py312-django42]
+        toxenv: [py312-django42, py312-django52]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -31,11 +31,14 @@ the SGA XBlock in devstack.**
     storages system. You can now define all your custom or third-party storage backends using
     the STORAGES dictionary in your settings. 
     
+    Do not use both DEFAULT_FILE_STORAGE and STORAGES in your settings.
+    They are mutually exclusive, and you should use only one of these options.
 
     ```
     MEDIA_ROOT = "/edx/var/edxapp/uploads"
+   
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
-    
+    or
     STORAGES = {
         # The default file storage backend (fallback for user-uploaded media, etc.)
         "default": {
@@ -58,7 +61,7 @@ the SGA XBlock in devstack.**
         },
     }
     ```
-    
+
     You can also configure S3 to be used as the file storage backend. Ask a fellow developer or devops for the
     correct settings to enable this. If you're using ansible to provision devstack, you may want to refer to 
     [this edX article on configuring data storage](https://openedx.atlassian.net/wiki/spaces/OpenOPS/pages/112001105/Configuring+Data+Storage).

--- a/README.md
+++ b/README.md
@@ -25,10 +25,38 @@ the SGA XBlock in devstack.**
 
     To configure SGA to use local storage, edit `lms/envs/private.py`
     to include these settings (and create the file if it doesn't exist yet):
+    
+    Starting with Django 4.2, the `get_storage_class` function has been deprecated and is scheduled
+    for removal in Django 5.2. To ensure forward compatibility, Django has introduced a new 
+    storages system. You can now define all your custom or third-party storage backends using
+    the STORAGES dictionary in your settings. 
+    
 
     ```
     MEDIA_ROOT = "/edx/var/edxapp/uploads"
     DEFAULT_FILE_STORAGE = 'django.core.files.storage.FileSystemStorage'
+    
+    STORAGES = {
+        # The default file storage backend (fallback for user-uploaded media, etc.)
+        "default": {
+            "BACKEND": "django.core.files.storage.FileSystemStorage",
+        },
+    
+        # Static files storage (used by collectstatic etc.)
+        "staticfiles": {
+            "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+        },
+    
+        # Your SGA-specific storage backend
+        "sga_storage": {
+            "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
+            "OPTIONS": {
+                "bucket_name": "sga",
+                "default_acl": "public-read",
+                "location": "sga/images",
+            },
+        },
+    }
     ```
     
     You can also configure S3 to be used as the file storage backend. Ask a fellow developer or devops for the

--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -182,7 +182,7 @@ class StaffGradedAssignmentXBlock(
 
     @classmethod
     def parse_xml(cls, node, runtime, keys):
-        # pylint: disable=arguments-differ,unused-argument
+        # pylint: disable=unused-argument
         """
         Override default serialization to handle <solution /> elements
         """

--- a/edx_sga/test_settings.py
+++ b/edx_sga/test_settings.py
@@ -61,7 +61,6 @@ DATABASES = {
 LANGUAGE_CODE = "en-us"
 TIME_ZONE = "UTC"
 USE_I18N = True
-USE_L10N = True
 USE_TZ = True
 STATIC_URL = "/static/"
 TECH_SUPPORT_EMAIL = "support@example.com"

--- a/edx_sga/tests/test_sga.py
+++ b/edx_sga/tests/test_sga.py
@@ -181,7 +181,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
         Set values on block from file upload.
         """
         try:
-            now = datetime.datetime.now(datetime.UTC)  # pylint: disable=no-member
+            now = datetime.datetime.now(datetime.UTC)
         except:  # pylint: disable=bare-except
             now = datetime.datetime.utcnow()
         now = now.replace(
@@ -749,7 +749,7 @@ class StaffGradedAssignmentMockedTests(TempfileMixin):
         """
         block = self.make_xblock()
         try:
-            timestamp = datetime.datetime.now(datetime.UTC)  # pylint: disable=no-member
+            timestamp = datetime.datetime.now(datetime.UTC)
         except:  # pylint: disable=bare-except
             timestamp = datetime.datetime.utcnow()
         get_sorted_submissions.return_value = [

--- a/edx_sga/tests/test_utils.py
+++ b/edx_sga/tests/test_utils.py
@@ -55,3 +55,32 @@ def test_get_default_storage_without_settings_override():
     """
     storage = get_default_storage()
     assert storage == default_storage
+
+@override_settings(
+    SGA_STORAGE_SETTINGS=None
+)
+def test_sga_backend_with_default():
+    """ verify the storage in case of STORAGES"""
+    storage = get_default_storage()
+    assert storage.__class__ == default_storage.__class__
+
+@override_settings(
+    SGA_STORAGE_SETTINGS=None,
+    STORAGES={
+        'sga_storage': {
+            'BACKEND': 'storages.backends.s3boto3.S3Boto3Storage',
+            'OPTIONS': {
+                'bucket_name': 'sga',
+                'default_acl': 'public',
+                'location': 'sga/images',
+            }
+        }
+    }
+)
+def test_sga_backend_with_new_sga_settings():
+    """ verify the sga-storage in case of STORAGES dict"""
+    storage = get_default_storage()
+    assert storage.__class__ == S3Boto3Storage
+    assert storage.bucket_name, "sga"
+    assert storage.default_acl, 'public'
+    assert storage.location, "sga/images"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{312}-django{32,42}
+envlist = py{312}-django{42,52}
 
 [testenv]
 passenv =
@@ -7,8 +7,8 @@ passenv =
     CI
 
 deps =
-    django32: Django>=3.2,<3.3
     django42: Django>=4.2,<5.0
+    django52: Django>=5.2,<5.3
     -r test_requirements.txt
 
 commands =


### PR DESCRIPTION
https://github.com/openedx/public-engineering/issues/358

Related [ticket](https://github.com/openedx/edx-platform/issues/36746) in edx-platform

TODO: Owning team test this before release.

----

- Adding django52 support.
- Upgrading **get_storage_class** which is removed in django52. 
- Updating tox and github actions for django42 and 52.

**Django 4.2** introduced the **STORAGES** setting, a modern and more flexible mechanism for configuring multiple storage backends. As of Django 5.2, **DEFAULT_FILE_STORAGE** and **STORAGES** are mutually exclusive, and using both simultaneously will raise an ImproperlyConfigured error.

In future STORAGES setting you can add to your Django settings to cover all your backends—old and new—using the dict syntax:

```
STORAGES = {
    # The default file storage backend (fallback for user-uploaded media, etc.)
    "default": {
        "BACKEND": "django.core.files.storage.FileSystemStorage",
    },

    # Static files storage (used by collectstatic, whitenoise, etc.)
    "staticfiles": {
        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
    },

    # Your SGA-specific storage backend
    "sga_storage": {
        "BACKEND": "storages.backends.s3boto3.S3Boto3Storage",
        "OPTIONS": {
            "bucket_name": "sga",
            "default_acl": "public-read",
            "location": "sga/images",
        },
    },
}
