### PR TITLE
chore: run CI on teak branch of open edx, remove redwood

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         python-version: ['3.12']
-        edx_branch: ['master', 'open-release/redwood.master', 'open-release/sumac.master']
+        edx_branch: ['master', 'open-release/sumac.master', 'release/teak']
         toxenv: [py312-django42, py312-django52]
 
     steps:
@@ -46,13 +46,13 @@ jobs:
 
       - name: Install tutor
         run: |
-          if [[ "${{ matrix.edx_branch }}" == "open-release/redwood.master" ]]; then
-            pip install tutor==18.2.2
+          if [[ "${{ matrix.edx_branch }}" == "open-release/sumac.master" ]]; then
+            pip install "tutor>=19.0.0,<20.0.0"
           elif [[ "${{ matrix.edx_branch }}" == "master" ]]; then
             git clone --branch=main https://github.com/overhangio/tutor.git
             pip install -e "./tutor"
-          else
-            pip install tutor==19.0.0
+          else 
+            pip install "tutor>=20.0.0,<21.0.0"
           fi
 
       - name: Set up tutor with edx-platform


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
- Enables the CI on Teak release of edX and removes the redwood branch
- Removes the redwood branch tests

#### How should this be manually tested?
- The CI should pass.
- The CI should runs tests against teak, sumac and master branches of Open edx
