### PR TITLE
fix: CI breaking on an external package (fancycompleter)

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -11,7 +11,7 @@ edx-opaque-keys
 edx-submissions==3.6.0
 jsonfield==3.1.0
 mako==1.2.4
-pdbpp==0.10.3
+pdbpp==0.11.6
 pylint==3.0.3
 pylint-celery==0.3
 pylint-django==2.5.5


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
The CI was breaking upon setting up tox/pdbpp packages from the test_requirements. The broken lines of code were associated with a package `fancycompleter` that pdbpp uses. Instead of pinning the `fancycompleter` in our requirements I upgraded the pdbpp package, which would have been the right way to fix this. It's ideal that the package that uses a broken dependency should be upgraded to fix the issue.

#### How should this be manually tested?
The CI should pass
(Required)

#### Where should the reviewer start?
Check the CI
(Optional)

#### Any background context you want to provide?
This issue was first noticed in https://github.com/mitodl/edx-sga/pull/368 and the author had to pin the dependency, We should instead bump the parent dependency to fix it, which is what I have done in this PR.
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
