### PR TITLE
fix: Update GH Actions runner OS to latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-24.04]
         python-version: ['3.12']
         toxenv: [py312-django32, py312-django42]
 


### PR DESCRIPTION
Ubuntu 20.04 is deprecated in favor of more recent versions

(cherry picked from commit 4d09e28d7694909c0f75ffed4208d1c8fc5ddcd0)

#### What are the relevant tickets?
(Required)

#### What's this PR do?
(Required)

#### How should this be manually tested?
(Required)

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
(Optional)

#### Screenshots (if appropriate)
(Optional)

#### What GIF best describes this PR or how it makes you feel?
(Optional)
