### PR TITLE
fix: check actual storage instance instead of removed DEFAULT_FILE_STORAGE setting

### DIFF
--- a/edx_sga/utils.py
+++ b/edx_sga/utils.py
@@ -9,6 +9,7 @@ from functools import partial
 
 import pytz
 from django.conf import settings
+from django.core.files.storage import FileSystemStorage
 from django.core.files.storage import default_storage as django_default_storage
 from django.core.files.storage import storages
 from django.utils.module_loading import import_string
@@ -85,8 +86,7 @@ def get_file_modified_time_utc(file_path):
         # time.tzname returns a 2 element tuple:
         #   (local non-DST timezone, e.g.: 'EST', local DST timezone, e.g.: 'EDT')
         pytz.timezone(time.tzname[0])
-        if settings.DEFAULT_FILE_STORAGE
-        == "django.core.files.storage.FileSystemStorage"
+        if isinstance(default_storage, FileSystemStorage)
         else pytz.utc
     )
 


### PR DESCRIPTION
# PR Description
#### What are the relevant tickets?
[#377](https://github.com/mitodl/edx-sga/issues/377)

#### What's this PR do?

Fixes a runtime `AttributeError` crash in `get_file_modified_time_utc()` on Django 4.2+ caused by a direct string comparison against `settings.DEFAULT_FILE_STORAGE`, which was removed in Django 4.2.

The fix replaces the string comparison with an `isinstance` check against the actual storage instance returned by `default_storage`. This is more correct than a `STORAGES` dict lookup because `get_default_storage()` resolves storage with priority: `sga_storage` → `SGA_STORAGE_SETTINGS` → Django's default — checking `STORAGES["default"]["BACKEND"]` would only cover the third case.

**Before:**
```python
file_timezone = (
    pytz.timezone(time.tzname[0])
    if settings.DEFAULT_FILE_STORAGE
    == "django.core.files.storage.FileSystemStorage"
    else pytz.utc
)
```

**After:**
```python
file_timezone = (
    pytz.timezone(time.tzname[0])
    if isinstance(default_storage, FileSystemStorage)
    else pytz.utc
)
```

#### How should this be manually tested?

1. Run Open edX on Django 4.2+ (e.g. Sumac via Tutor) with `STORAGES` exclusively — no `DEFAULT_FILE_STORAGE` in settings.
2. Add an `edx_sga` Staff Graded Assignment block to a course and have a student submit a file.
3. As a staff user, click **Collect ALL Submissions** — first click creates the zip via Celery. No error.
4. Click the download button **a second time** (zip already exists):
   - **Without fix**: crashes with `AttributeError: 'Settings' object has no attribute 'DEFAULT_FILE_STORAGE'` → HTTP 500.
   - **With fix**: correctly determines the file timezone based on the actual storage backend and serves or recreates the zip.

#### Where should the reviewer start?

`edx_sga/utils.py` — `get_file_modified_time_utc()`

#### Any background context you want to provide?

**What PR #368 missed:**
PR #368 added Django 5.2 support by replacing `get_storage_class()` with `import_string()` and updating `get_default_storage()` to use the new `STORAGES` dict. However, `get_file_modified_time_utc()` still contained a direct `settings.DEFAULT_FILE_STORAGE` string comparison that was not updated.

**Why a settings string lookup is insufficient:**
`get_default_storage()` resolves the actual storage backend with this priority: `sga_storage` → `SGA_STORAGE_SETTINGS` → Django's default. Checking `STORAGES["default"]["BACKEND"]` would only reflect the third case, producing incorrect timezone handling for any deployment using `sga_storage` or `SGA_STORAGE_SETTINGS`. Using `isinstance(default_storage, FileSystemStorage)` checks the actual storage in use regardless of how it was configured.

**Why the bug is easy to miss:**
`get_file_modified_time_utc()` is only called inside the `if self.is_zip_file_available(user):` branch of `prepare_download_submissions`. On the first click the zip doesn't exist yet, so this branch is skipped and no error occurs. The crash only surfaces on the **second click**, when an existing zip is found and its modification time needs to be checked.

**Error seen in production:**
```
File ".../edx_sga/sga.py", line 506, in prepare_download_submissions
    zip_file_time = get_file_modified_time_utc(zip_file_path)
File ".../edx_sga/utils.py", line 88, in get_file_modified_time_utc
    if settings.DEFAULT_FILE_STORAGE
AttributeError: 'Settings' object has no attribute 'DEFAULT_FILE_STORAGE'
```
