### PR TITLE
chore: remove web-fragments as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup(
     install_requires=[
         "XBlock",
         "xblock-utils",
-        "web_fragments",
     ],
     entry_points={
         "xblock.v1": [

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,6 @@ setup(
     ],
     install_requires=[
         "XBlock",
-        "xblock-utils",
     ],
     entry_points={
         "xblock.v1": [

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -24,5 +24,4 @@ six==1.16.0
 tox
 tox-battery
 
-xblock-utils==3.4.1
 xblock-sdk==0.9.0


### PR DESCRIPTION
#### What are the relevant tickets?

https://github.com/openedx/web-fragments/issues/309

#### What's this PR do?

This PR removes web-fragments as a dependency now that XBlock incorporates it into its packaging.

#### How should this be manually tested?

Verify the block loads in the workbench. If the block is incompatible with the workbench, verify it loads in the LMS.

#### Where should the reviewer start?

Verify CI is passing.

#### Any background context you want to provide?

https://github.com/openedx/XBlock/pull/917