### PR TITLE
fix: allow CCX staff to grade assignments without approval

### DIFF
--- a/edx_sga/sga.py
+++ b/edx_sga/sga.py
@@ -37,6 +37,7 @@ from web_fragments.fragment import Fragment
 from xblock.utils.studio_editable import StudioEditableXBlockMixin
 from xmodule.contentstore.content import StaticContent
 from xmodule.util.duedate import get_extended_due_date
+from ccx_keys.locator import CCXLocator
 
 from edx_sga.constants import ATTR_KEY_ANONYMOUS_USER_ID, ATTR_KEY_USER_IS_STAFF, ATTR_KEY_USER_ROLE, ITEM_TYPE
 from edx_sga.showanswer import ShowAnswerXBlockMixin
@@ -919,6 +920,10 @@ class StaffGradedAssignmentXBlock(
         Check if user role is instructor.
         """
         if user_service := self.runtime.service(self, 'user'):
+            # If it's a CCX course, the coach (staff role) or course admin (instructor role)
+            # must be able to grade assignments without requiring instructor approval.
+            if isinstance(self.course_id, CCXLocator):
+                return user_service.get_current_user().opt_attrs.get(ATTR_KEY_USER_ROLE) in ('staff', 'instructor')
             return user_service.get_current_user().opt_attrs.get(ATTR_KEY_USER_ROLE) == "instructor"
         return False
 


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #384

#### What's this PR do?
This PR updates the is_instructor method to correctly authorize CCX coaches to grade assignments. Out-of-the-box, the method only validates users with the "instructor" role. This update checks if the course_id is an instance of CCXLocator. If it is, it allows users with either the 'staff' or 'instructor' role to validate as instructors, enabling them to grade submissions directly without requiring explicit instructor approval.

#### How should this be manually tested?
0. Install the SGA plugin (LMS and CMS).
1. Create a main course and add an SGA component.
2. Create a new CCX course derived from the main course.
3. Log in as a student user and submit a test assignment in the CCX course.
4. Log in as a user with the CCX coach (staff) role.
5. Navigate to the unit containing the SGA component and click the "Grade Submissions" button.
6. Enter a grade. Verify that the grade is applied immediately via the submissions API and does not get stuck on "Awaiting instructor approval".
7. Log back in as the student user, navigate to the Progress page, and verify that the grade is successfully assigned.

#### Where should the reviewer start?
The reviewer should look at the is_instructor() method in the main block Python file, where the CCXLocator import and the role validation logic were added.

#### Any background context you want to provide?
In the course access role model, CCX coaches are assigned the staff role, while standard course admins get the instructor role. Because SGA previously strictly checked for "instructor", CCX coaches were saving grades to staff_score in the module state instead of the submissions API, making it impossible to finalize grades in CCX courses.

#### Screenshots 
**Before the fix (As a CCX Coach):**
The coach could enter a grade, but it remained stuck with an "(Awaiting instructor approval)" message and was never reflected in the student's progress.

<img width="1025" height="604" alt="image" src="https://github.com/user-attachments/assets/654dbc9b-1bcb-49f3-9fbc-8dc36f9f9f02" />


**After the fix (As a CCX Coach):**
The grade is now processed immediately, the warning message is gone, and the score is correctly reflected in the student's progress.

<img width="1025" height="601" alt="image" src="https://github.com/user-attachments/assets/b1d50a67-a25d-4fef-b840-0e26d8a9cd43" />


